### PR TITLE
Update to node v18

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.15.1"
+          node-version: "18.x"
           cache: "npm"
 
       - run: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.19.0 as build
+FROM node:18-alpine3.17 as build
 
 ARG COMMIT_SHA
 ENV APP_VERSION=$COMMIT_SHA
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . ./
 RUN npm pkg delete scripts.prepare && npm ci && npm run build && npm prune --production
 
-FROM node:16.19.0-alpine3.16
+FROM node:18-alpine3.17
 RUN apk add --no-cache dumb-init \
   && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ First draft of implementing a platform to create requests to the Rechtsantragste
 
 ### Requirements
 
-- Node.js >= 16.0.0
+- Node.js >= 18.0.0
 - npm 7 or greater
 - A strapi instance (https://github.com/digitalservicebund/a2j-rechtsantragstelle-strapi) and a configured .env file (see .env.example)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "http-cache-semantics": "^4.1.1",
         "isbot": "^3.6.10",
         "libphonenumber-js": "^1.10.30",
-        "marked": "^4.3.0",
+        "marked": "^5.0.1",
         "prettier-plugin-sh": "^0.12.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11427,14 +11427,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Nn9peC4lvIZdcfp8Uze6xk4ZYowkcj/K6+e/6rLHadhtjqeip/bYRxMgt3124IGGJ3RPs2uX5YVmAGbUutY18g==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "http-cache-semantics": "^4.1.1",
     "isbot": "^3.6.10",
     "libphonenumber-js": "^1.10.30",
-    "marked": "^4.3.0",
+    "marked": "^5.0.1",
     "prettier-plugin-sh": "^0.12.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Node 16 has EOL in September 23, and our first dependency (`Marked`) got bumped to a min version of 18.

Also replaces https://github.com/digitalservicebund/a2j-rechtsantragstelle/pull/97