### PR TITLE
feat: add CSRF header to steps

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -30,6 +30,7 @@ import ErrorBox from "./components/ErrorBox";
 import errorMessage from "./util/errorMessage";
 import { createCSRFSession } from "./services/security/csrf.server";
 import { commitSession } from "./sessions";
+import { CSRFKey } from "./services/security/csrf";
 
 export const headers: HeadersFunction = () => ({
   // "Content-Security-Policy": "TODO",
@@ -65,7 +66,7 @@ export const loader = async ({ request }: LoaderArgs) => {
   }
   return json(
     {
-      csrf,
+      [CSRFKey]: csrf,
       breadcrumbs: await breadcrumbsFromURL(request.url),
       footer: getFooterProps(await getStrapiFooter()),
       hasTrackingConsent: await hasTrackingConsent({ request }),

--- a/app/services/security/csrf.server.ts
+++ b/app/services/security/csrf.server.ts
@@ -1,0 +1,48 @@
+//https://sergiodxa.com/articles/adding-csrf-protection-to-remix
+import type { Session } from "@remix-run/node";
+import { randomBytes } from "crypto";
+import { getSession } from "~/sessions";
+import { CSRFKey } from "./csrf";
+
+export function createCSRFToken() {
+  return randomBytes(100).toString("base64");
+}
+
+export async function validateCSRFToken(request: Request, session: Session) {
+  // first we parse the body, be sure to clone the request so you can parse the body again in the future
+  const body = Object.fromEntries(
+    new URLSearchParams(await request.clone().text()).entries(),
+  ) as { csrf?: string };
+  // then we throw an error if one of our validations didn't pass
+  if (!session.has(CSRFKey))
+    throw new Error("Session: CSRF Token not included.");
+  if (!body.csrf) throw new Error("Body: CSRF Token not included.");
+  if (body.csrf !== session.get(CSRFKey))
+    throw new Error(
+      `CSRF tokens do not match. body: ${body.csrf}, session: ${session.get(
+        CSRFKey,
+      )}`,
+    );
+  // we don't need to return anything, if the validation fail it will throw an error
+}
+
+export async function createCSRFSession(request: Request) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const csrf = createCSRFToken();
+  session.set(CSRFKey, csrf);
+  return { session, csrf };
+}
+
+export async function validatedSession(request: Request) {
+  const session = await getSession(request.headers.get("Cookie"));
+  try {
+    await validateCSRFToken(request, session);
+  } catch (error) {
+    if (error instanceof Error) {
+      session.flash("error", error.message);
+      console.error(error.message);
+    }
+    return;
+  }
+  return session;
+}

--- a/app/services/security/csrf.ts
+++ b/app/services/security/csrf.ts
@@ -1,0 +1,6 @@
+export const CSRFKey = "csrf";
+
+export function csrfFromRouteLoader(routeLoaderdata: unknown) {
+  if (routeLoaderdata)
+    return (routeLoaderdata as Record<string, string>)[CSRFKey];
+}


### PR DESCRIPTION
Adds csfr header validation to all step submissions:
- root returns key in loader and session
- step renders key in hidden form element & checks match in action