### PR TITLE
chore: remove basic http authentication

### DIFF
--- a/.github/actions/production-text-test/action.yml
+++ b/.github/actions/production-text-test/action.yml
@@ -1,9 +1,5 @@
 name: "Test Production Text"
 description: "Check that a specific text is displayed on the production system"
-inputs:
-  PRODUCTION_BASIC_AUTH_TOKEN:
-    description: "Token to use for accessing the production environment"
-    required: true
 
 runs:
   using: "composite"
@@ -12,4 +8,4 @@ runs:
 
     - name: Execute text-test script
       shell: bash
-      run: sh .github/actions/production-text-test/test-text.sh ${{ inputs.PRODUCTION_BASIC_AUTH_TOKEN }}
+      run: sh .github/actions/production-text-test/test-text.sh

--- a/.github/actions/production-text-test/test-text.sh
+++ b/.github/actions/production-text-test/test-text.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-PRODUCTION_URL="https://a2j-rast.prod.ds4g.net/"
+PRODUCTION_URL="https://service.justiz.de"
 TEXT="Justiz-Services"
 
-if curl -s $PRODUCTION_URL --header "Authorization: Basic $1" | grep -o "$TEXT"; then
+if curl -s $PRODUCTION_URL | grep -o "$TEXT"; then
   echo "Text found"
   exit 0
 else

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -189,5 +189,3 @@ jobs:
 
       - name: Run text test
         uses: ./.github/actions/production-text-test
-        with:
-          PRODUCTION_BASIC_AUTH_TOKEN: "${{ secrets.PRODUCTION_BASIC_AUTH_TOKEN }}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ test.env
 Dockerfile
 .gitignore
 *.snap
+*.sh


### PR DESCRIPTION
- [x] Remove auth header from post-verification check
- [ ] Remove `PRODUCTION_BASIC_AUTH_TOKEN` from GitHub Secrets

note:
- error was thrown: `[error] No parser could be inferred for file ".github/actions/production-text-test/test-text.sh".`
I excluded `.sh` because of missing a prettier parser 
- The curl request won't trigger a tracking event 👍