### PR TITLE
feat(posthog): add custom event for cookie consent and unify event handling

### DIFF
--- a/app/routes/action.send-rating.ts
+++ b/app/routes/action.send-rating.ts
@@ -34,7 +34,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   sendCustomEvent({
     eventName: "rating given",
     request,
-    properties: { wasHelpful: userRatings[url], context },
+    properties: {
+      wasHelpful: userRatings[url],
+      context,
+    },
   });
 
   return clientJavaScriptAvailable

--- a/app/routes/action.send-rating.ts
+++ b/app/routes/action.send-rating.ts
@@ -3,9 +3,8 @@ import { json, redirect } from "@remix-run/node";
 import { BannerState } from "~/components/UserFeedback";
 import { userRatingFieldname } from "~/components/UserFeedback/RatingBox";
 import { getSessionForContext } from "~/services/session.server";
-import { config } from "~/services/env/web";
 import { bannerStateName } from "~/services/feedback/handleFeedback";
-import { getPosthogClient } from "~/services/analytics/posthogClient.server";
+import { sendCustomEvent } from "~/services/analytics/customEvent";
 
 export const loader = () => redirect("/");
 
@@ -32,11 +31,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const headers = { "Set-Cookie": await commitSession(session) };
 
-  getPosthogClient()?.capture({
-    distinctId: config().ENVIRONMENT,
-    event: "rating given",
-    // eslint-disable-next-line camelcase
-    properties: { wasHelpful: userRatings[url], $current_url: url, context },
+  sendCustomEvent({
+    eventName: "rating given",
+    request,
+    properties: { wasHelpful: userRatings[url], context },
   });
 
   return clientJavaScriptAvailable

--- a/app/routes/action.set-analytics.tsx
+++ b/app/routes/action.set-analytics.tsx
@@ -8,8 +8,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const { searchParams } = new URL(request.url);
   const clientJavaScriptAvailable = searchParams.get("js");
 
-  const cookie = await consentCookieFromRequest({ request });
-  const headers = { "Set-Cookie": cookie };
+  const headers = await consentCookieFromRequest({ request });
 
   if (clientJavaScriptAvailable) {
     return json({ success: true }, { headers });

--- a/app/routes/cookie-einstellungen.tsx
+++ b/app/routes/cookie-einstellungen.tsx
@@ -19,7 +19,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const headers = { "Set-Cookie": await consentCookieFromRequest({ request }) };
+  const headers = await consentCookieFromRequest({ request });
   return redirect("/cookie-einstellungen/erfolg", { headers });
 }
 

--- a/app/routes/shared/step.server.ts
+++ b/app/routes/shared/step.server.ts
@@ -37,6 +37,7 @@ import {
   deleteFromArrayInplace,
 } from "~/services/session.server/arrayDeletion";
 import type { StrapiMeta } from "~/services/cms/models/StrapiMeta";
+import { hasTrackingConsent } from "~/services/analytics/gdprCookie.server";
 
 const structureCmsContent = (
   formPageContent: z.infer<
@@ -301,8 +302,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   });
 
   const customEventName = flowController.getMeta(stepId)?.customEventName;
-  if (customEventName)
-    void sendCustomEvent(customEventName, validationResult.data, request);
+  if (customEventName && (await hasTrackingConsent({ request })))
+    sendCustomEvent({
+      eventName: customEventName,
+      context: validationResult.data,
+      request,
+    });
 
   const returnTo = formData.get("_returnTo");
   const destination =

--- a/app/routes/shared/step.server.ts
+++ b/app/routes/shared/step.server.ts
@@ -304,9 +304,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const customEventName = flowController.getMeta(stepId)?.customEventName;
   if (customEventName && (await hasTrackingConsent({ request })))
     sendCustomEvent({
-      eventName: customEventName,
-      context: validationResult.data,
       request,
+      eventName: customEventName,
+      properties: { context: validationResult.data },
     });
 
   const returnTo = formData.get("_returnTo");

--- a/app/services/analytics/customEvent.ts
+++ b/app/services/analytics/customEvent.ts
@@ -1,9 +1,9 @@
 import { config } from "../env/web";
 import { parse } from "cookie";
 import { getPosthogClient } from "./posthogClient.server";
-import type { Context } from "~/models/flows/contexts";
 
 function idFromCookie(request: Request) {
+  // console.log("request", request)
   // Note: can't use cookie.parse(): https://github.com/remix-run/remix/discussions/5198
   // Returns ENVIRONMENT if posthog's distinct_id can't be extracted
   const { POSTHOG_API_KEY, ENVIRONMENT } = config();
@@ -17,19 +17,19 @@ function idFromCookie(request: Request) {
 export function sendCustomEvent({
   request,
   eventName,
-  context,
   properties,
 }: {
   request: Request;
   eventName: string;
-  context?: Context;
-  properties?: Record<string, string | boolean | undefined>;
+  properties?: Record<
+    string,
+    string | boolean | Record<string, string | boolean>
+  >;
 }) {
   getPosthogClient()?.capture({
     distinctId: idFromCookie(request),
     event: eventName,
     properties: {
-      ...context,
       // eslint-disable-next-line camelcase
       $current_url: new URL(request.url).pathname,
       ...properties,

--- a/app/services/feedback/handleFeedback.ts
+++ b/app/services/feedback/handleFeedback.ts
@@ -6,9 +6,8 @@ import {
 } from "~/components/UserFeedback/FeedbackFormBox";
 import { userRatingFieldname } from "~/components/UserFeedback/RatingBox";
 import { validationError } from "remix-validated-form";
-import { config } from "../env/web";
 import { type Session, redirect } from "@remix-run/node";
-import { getPosthogClient } from "../analytics/posthogClient.server";
+import { sendCustomEvent } from "../analytics/customEvent";
 
 export const bannerStateName = "bannerState";
 
@@ -30,14 +29,12 @@ export const handleFeedback = async (formData: FormData, request: Request) => {
     return validationError(result.error, result.submittedData);
   }
   bannerState[pathname] = BannerState.FeedbackGiven;
-  getPosthogClient()?.capture({
-    distinctId: config().ENVIRONMENT,
-    event: "feedback given",
+  sendCustomEvent({
+    eventName: "feedback given",
+    request,
     properties: {
       wasHelpful: userRating[pathname],
       feedback: result.data?.feedback ?? "",
-      // eslint-disable-next-line camelcase
-      $current_url: pathname,
       context,
     },
   });


### PR DESCRIPTION
Actually I just wanted to quickly add the event to the cookie-consent, then I tried to standardize the event handling. Feedback appreciated 🙏😁