### PR TITLE
feat(pdf): introduce rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "compression": "^1.7.4",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.2.0",
         "fflate": "^0.8.2",
         "haversine-distance": "^1.2.1",
         "ioredis": "^5.4.1",
@@ -11744,6 +11745,20 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.2.0.tgz",
+      "integrity": "sha512-T7nul1t4TNyfZMJ7pKRKkdeVJWa2CqB8NA1P8BwYaoDI5QSBZARv5oMS43J7b7I5P+4asjVXjb7ONuwDKucahg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/cookie-signature": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "compression": "^1.7.4",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.2.0",
     "fflate": "^0.8.2",
     "haversine-distance": "^1.2.1",
     "ioredis": "^5.4.1",

--- a/server.js
+++ b/server.js
@@ -62,6 +62,8 @@ app.use(
     max: 2, // Limit each IP to 2 requests per 2s
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    message:
+      "<html lang='de'><head><title>Justiz Services - Fehler aufgetreten</title></head><body>Es sind zu viele Anfragen zum Herunterladen des PDFs innerhalb kurzer Zeit gestellt worden. Bitte versuchen Sie es später noch einmal.</body></html>",
   }),
 );
 

--- a/server.js
+++ b/server.js
@@ -54,15 +54,16 @@ isStagingOrPreviewEnvironment
   ? app.use(staticFileServer)
   : app.use(mountPathWithoutStorybook, staticFileServer);
 
-// limit calls to pdf download
-const limiter = rateLimit({
-  windowMs: 2 * 1000,
-  max: 2, // Limit each IP to 2 requests per 2s
-  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-});
-
-app.use("/*/pdf", limiter);
+// Limit calls to routes ending in /pdf or /pdf/, as they are expensive
+app.use(
+  /.*\/pdf(\/|$)/,
+  rateLimit({
+    windowMs: 2 * 1000,
+    max: 2, // Limit each IP to 2 requests per 2s
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  }),
+);
 
 // handle SSR requests
 app.all("*", remixHandler);

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ app.use(
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     message:
-      "<html lang='de'><head><title>Justiz Services - Fehler aufgetreten</title></head><body>Es sind zu viele Anfragen zum Herunterladen des PDFs innerhalb kurzer Zeit gestellt worden. Bitte versuchen Sie es später noch einmal.</body></html>",
+      '<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"><title>Justiz Services - Fehler aufgetreten</title><style>html{font-family:BundesSansWeb,Calibri,Verdana,Arial,Helvetica,sans-serif;font-size:1.125rem;line-height:1.75rem}body{max-width:59rem;margin:6rem auto;padding:0 2rem}h1{font-size:1.875rem;padding-bottom:1.5rem}</style></head><body><h1>Justiz Service ist vorübergehend nicht erreichbar</h1><p>Es sind zu viele Anfragen zum Herunterladen des PDFs innerhalb kurzer Zeit gestellt worden. Bitte versuchen Sie es später noch einmal.</p></body></html>',
   }),
 );
 


### PR DESCRIPTION
The `*/pdf` route is quite expensive and will burn the CPU before any network-level rate limiting catches on.

This will allow only 2 calls per 2 seconds, happy to discuss better defaults here.
My reasoning was that this will allow the odd miss-click but effectively throttles any malicious request to 1 per second