### PR TITLE
Rate limit redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ lefthook-local.yml
 # Gerichtsfinder data
 **/gerichtsfinder/_data/
 
+# local Redis TLS certs
+/certs
+
 /.vscode/
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -15,9 +15,22 @@ First draft of implementing a platform to create requests to the Rechtsantragste
 
 ### Run Server in Development Mode
 
+#### Start a Redis instance with TLS setup
+
+1. Create TLS certificate + key: [Here](https://serverfault.com/questions/224122/what-is-crt-and-key-files-and-how-to-generate-them) is how.
+   You can pass dummy information into the certificate.
+
+2. Name the files redis-server.crt and put them in a /cert folder.
+3. Start the redis:
+
+```
+docker compose up -d
+```
+
+#### Start the development server
+
 ```sh
 npm install
-docker compose up -d
 npm run dev
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,14 @@ services:
     container_name: local-redis
     ports:
       - "6380:6379"
+    volumes:
+      - ./certs/redis-server.crt:/usr/local/etc/redis/redis-server.crt
+      - ./certs/redis-server.key:/usr/local/etc/redis/redis-server.key
+
+    command: >
+      redis-server
+      --tls-port 6379
+      --port 0
+      --tls-cert-file /usr/local/etc/redis/redis-server.crt
+      --tls-key-file /usr/local/etc/redis/redis-server.key
+      --tls-auth-clients no

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "pdf-lib": "^1.17.1",
         "posthog-js": "^1.136.2",
         "posthog-node": "^4.0.1",
+        "rate-limit-redis": "^4.2.0",
         "react": "^18.3.1",
         "react-collapsed": "^4.1.2",
         "react-dom": "^18.3.1",
@@ -21197,6 +21198,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.2.0.tgz",
+      "integrity": "sha512-wV450NQyKC24NmPosJb2131RoczLdfIJdKCReNwtVpm5998U8SgKrAZrIHaN/NfQgqOHaan8Uq++B4sa5REwjA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "pdf-lib": "^1.17.1",
     "posthog-js": "^1.136.2",
     "posthog-node": "^4.0.1",
+    "rate-limit-redis": "^4.2.0",
     "react": "^18.3.1",
     "react-collapsed": "^4.1.2",
     "react-dom": "^18.3.1",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,10 @@
 import { wrapExpressCreateRequestHandler } from "@sentry/remix";
 import { createRequestHandler } from "@remix-run/express";
 import { rateLimit } from "express-rate-limit";
+import { RedisStore } from "rate-limit-redis";
 import compression from "compression";
 import express from "express";
+import RedisClient from "ioredis";
 
 const sentryCreateRequestHandler =
   wrapExpressCreateRequestHandler(createRequestHandler);
@@ -56,9 +58,15 @@ isStagingOrPreviewEnvironment
 
 app.set("trust proxy", 2);
 
+const redisUrl = () =>
+  `rediss://default:${process.env.REDIS_PASSWORD?.trim()}@${process.env.REDIS_ENDPOINT ?? "localhost:6380"}`;
+const client = new RedisClient(redisUrl(), {
+  tls: {
+    rejectUnauthorized: false,
+  },
+});
+
 // Limit calls to routes ending in /pdf or /pdf/, as they are expensive
-// Attention - this only limits to the number of requests *per pod*.
-// The more pods we have, the higher the effective limit goes up.
 app.use(
   /.*\/pdf(\/|$)/,
   rateLimit({
@@ -68,6 +76,9 @@ app.use(
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     message:
       '<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"><title>Justiz Services - Fehler aufgetreten</title><style>html{font-family:BundesSansWeb,Calibri,Verdana,Arial,Helvetica,sans-serif;font-size:1.125rem;line-height:1.75rem}body{max-width:59rem;margin:6rem auto;padding:0 2rem}h1{font-size:1.875rem;padding-bottom:1.5rem}</style></head><body><h1>Justiz Service ist vorübergehend nicht erreichbar</h1><p>Es sind zu viele Anfragen zum Herunterladen des PDFs innerhalb kurzer Zeit gestellt worden. Bitte versuchen Sie es später noch einmal.</p></body></html>',
+    store: new RedisStore({
+      sendCommand: (...args) => client.call(...args),
+    }),
   }),
 );
 


### PR DESCRIPTION
# The problem being solved
Our rate limiting before was specific to one pod, meaning that it will be higher if we have more pods -> beside the point of rate limiting.

# The solution
Use our existing redis for rate limiting -> one point where usage data is stored.
With that I had a lot of code duplication and thus with the idea of @chohner introduced the only-tls way. (Before, we had the local setup without TLS, leading to some logic that needed to be duplicated).
I have to say, I do like that the local setup is now closer to the rest of the setup.

# Questions/ considerations
- Do you see any further data privacy issues with this?
- Do you think the code-duplication has a decent amount? (it's not nicely possible to import the same code in `server.js` and `redis.ts`)
- Does the documentation + setup work for you on your machine?
- Do you see a point where this might break in other environments?