### PR TITLE
Add translations user feedback

### DIFF
--- a/app/components/UserFeedback/FeedbackFormBox.tsx
+++ b/app/components/UserFeedback/FeedbackFormBox.tsx
@@ -14,10 +14,10 @@ export const feedbackFormName = "feedbackForm";
 const feedbackFieldname = "feedback";
 const feedbackButtonFieldname = "feedbackButton";
 
-const HEADING_FEEDBACK_TRANSLATION_KEY = "heading-feedback";
-const PLACEHOLDER_FEEDBACK_TRANSLATION_KEY = "placeholder-feedback";
-const ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY = "abort-button-feedback";
-const SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY = "submit-button-feedback";
+export const HEADING_FEEDBACK_TRANSLATION_KEY = "heading-feedback";
+export const PLACEHOLDER_FEEDBACK_TRANSLATION_KEY = "placeholder-feedback";
+export const ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY = "abort-button-feedback";
+export const SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY = "submit-button-feedback";
 
 enum FeedbackButtons {
   Abort = "abort",

--- a/app/components/UserFeedback/FeedbackFormBox.tsx
+++ b/app/components/UserFeedback/FeedbackFormBox.tsx
@@ -3,6 +3,8 @@ import SendIcon from "@digitalservicebund/icons/SendOutlined";
 import { withZod } from "@remix-validated-form/with-zod";
 import { ValidatedForm } from "remix-validated-form";
 import { z } from "zod";
+import { getTranslationByKey } from "~/util/getTranslationByKey";
+import { useFeedbackTranslations } from "./FeedbackTranslationContext";
 import Button from "../Button";
 import ButtonContainer from "../ButtonContainer";
 import Heading from "../Heading";
@@ -11,6 +13,11 @@ import Textarea from "../inputs/Textarea";
 export const feedbackFormName = "feedbackForm";
 const feedbackFieldname = "feedback";
 const feedbackButtonFieldname = "feedbackButton";
+
+const HEADING_FEEDBACK_TRANSLATION_KEY = "heading-feedback";
+const PLACEHOLDER_FEEDBACK_TRANSLATION_KEY = "placeholder-feedback";
+const ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY = "abort-button-feedback";
+const SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY = "submit-button-feedback";
 
 enum FeedbackButtons {
   Abort = "abort",
@@ -34,50 +41,62 @@ export const feedbackValidator = withZod(
 
 export interface FeedbackBoxProps {
   readonly destination: string;
-  readonly heading: string;
-  readonly placeholder: string;
-  readonly abortButtonLabel: string;
-  readonly submitButtonLabel: string;
 }
 
-export const FeedbackFormBox = ({
-  destination,
-  heading,
-  placeholder,
-  abortButtonLabel,
-  submitButtonLabel,
-}: FeedbackBoxProps) => (
-  <>
-    <Heading look="ds-label-01-bold" tagName="h2" text={heading} />
-    <ValidatedForm
-      validator={feedbackValidator}
-      subaction={feedbackFormName}
-      method="post"
-      action={destination}
-    >
-      <div className="ds-stack-16">
-        <Textarea name={feedbackFieldname} placeholder={placeholder} />
-        <ButtonContainer>
-          <Button
-            iconLeft={<CloseIcon />}
-            look="tertiary"
-            name={feedbackButtonFieldname}
-            value={FeedbackButtons.Abort}
-            type="submit"
-          >
-            {abortButtonLabel}
-          </Button>
-          <Button
-            look="primary"
-            iconLeft={<SendIcon />}
-            name={feedbackButtonFieldname}
-            value={FeedbackButtons.Submit}
-            type="submit"
-          >
-            {submitButtonLabel}
-          </Button>
-        </ButtonContainer>
-      </div>
-    </ValidatedForm>
-  </>
-);
+export const FeedbackFormBox = ({ destination }: FeedbackBoxProps) => {
+  const { translations } = useFeedbackTranslations();
+
+  const heading = getTranslationByKey(
+    HEADING_FEEDBACK_TRANSLATION_KEY,
+    translations,
+  );
+  const placeholder = getTranslationByKey(
+    PLACEHOLDER_FEEDBACK_TRANSLATION_KEY,
+    translations,
+  );
+
+  const abortButtonLabel = getTranslationByKey(
+    ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY,
+    translations,
+  );
+  const submitButtonLabel = getTranslationByKey(
+    SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY,
+    translations,
+  );
+
+  return (
+    <>
+      <Heading look="ds-label-01-bold" tagName="h2" text={heading} />
+      <ValidatedForm
+        validator={feedbackValidator}
+        subaction={feedbackFormName}
+        method="post"
+        action={destination}
+      >
+        <div className="ds-stack-16">
+          <Textarea name={feedbackFieldname} placeholder={placeholder} />
+          <ButtonContainer>
+            <Button
+              iconLeft={<CloseIcon />}
+              look="tertiary"
+              name={feedbackButtonFieldname}
+              value={FeedbackButtons.Abort}
+              type="submit"
+            >
+              {abortButtonLabel}
+            </Button>
+            <Button
+              look="primary"
+              iconLeft={<SendIcon />}
+              name={feedbackButtonFieldname}
+              value={FeedbackButtons.Submit}
+              type="submit"
+            >
+              {submitButtonLabel}
+            </Button>
+          </ButtonContainer>
+        </div>
+      </ValidatedForm>
+    </>
+  );
+};

--- a/app/components/UserFeedback/FeedbackTranslationContext.tsx
+++ b/app/components/UserFeedback/FeedbackTranslationContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+import { Translations } from "~/services/cms/index.server";
+
+type FeedbackTranslationsContext = {
+  translations: Translations;
+};
+
+export const FeedbackTranslationContext =
+  createContext<FeedbackTranslationsContext>({ translations: {} });
+
+export function useFeedbackTranslations(): FeedbackTranslationsContext {
+  return useContext(FeedbackTranslationContext);
+}

--- a/app/components/UserFeedback/PostSubmissionBox.tsx
+++ b/app/components/UserFeedback/PostSubmissionBox.tsx
@@ -1,17 +1,27 @@
+import { getTranslationByKey } from "~/util/getTranslationByKey";
+import { useFeedbackTranslations } from "./FeedbackTranslationContext";
 import Heading from "../Heading";
 import RichText from "../RichText";
 
-export interface PostSubmissionBoxProps {
-  readonly heading: string;
-  readonly text: string;
-}
+const HEADING_POST_SUBMISSION_TRANSLATION_KEY = "heading-post-submission";
+const TEXT_POST_SUBMISSION_TRANSLATION_KEY = "text-post-submission";
 
-export const PostSubmissionBox = ({
-  heading,
-  text,
-}: PostSubmissionBoxProps) => (
-  <div data-testid="user-feedback-submission">
-    <Heading look="ds-label-01-bold" tagName="h2" text={heading} />
-    <RichText markdown={text} />
-  </div>
-);
+export const PostSubmissionBox = () => {
+  const { translations } = useFeedbackTranslations();
+
+  const heading = getTranslationByKey(
+    HEADING_POST_SUBMISSION_TRANSLATION_KEY,
+    translations,
+  );
+  const text = getTranslationByKey(
+    TEXT_POST_SUBMISSION_TRANSLATION_KEY,
+    translations,
+  );
+
+  return (
+    <div data-testid="user-feedback-submission">
+      <Heading look="ds-label-01-bold" tagName="h2" text={heading} />
+      <RichText markdown={text} />
+    </div>
+  );
+};

--- a/app/components/UserFeedback/PostSubmissionBox.tsx
+++ b/app/components/UserFeedback/PostSubmissionBox.tsx
@@ -3,8 +3,9 @@ import { useFeedbackTranslations } from "./FeedbackTranslationContext";
 import Heading from "../Heading";
 import RichText from "../RichText";
 
-const HEADING_POST_SUBMISSION_TRANSLATION_KEY = "heading-post-submission";
-const TEXT_POST_SUBMISSION_TRANSLATION_KEY = "text-post-submission";
+export const HEADING_POST_SUBMISSION_TRANSLATION_KEY =
+  "heading-post-submission";
+export const TEXT_POST_SUBMISSION_TRANSLATION_KEY = "text-post-submission";
 
 export const PostSubmissionBox = () => {
   const { translations } = useFeedbackTranslations();

--- a/app/components/UserFeedback/RatingBox.tsx
+++ b/app/components/UserFeedback/RatingBox.tsx
@@ -9,8 +9,8 @@ import ButtonContainer from "../ButtonContainer";
 import Heading from "../Heading";
 
 export const userRatingFieldname = "wasHelpful";
-const YES_RATING_BUTTON_LABEL_TRANSLATION_KEY = "yes-rating";
-const NO_RATING_BUTTON_LABEL_TRANSLATION_KEY = "no-rating";
+export const YES_RATING_BUTTON_LABEL_TRANSLATION_KEY = "yes-rating";
+export const NO_RATING_BUTTON_LABEL_TRANSLATION_KEY = "no-rating";
 
 export interface RatingBoxProps {
   readonly heading: string;

--- a/app/components/UserFeedback/RatingBox.tsx
+++ b/app/components/UserFeedback/RatingBox.tsx
@@ -2,30 +2,37 @@ import ThumbDownIcon from "@digitalservicebund/icons/ThumbDownOutlined";
 import ThumbUpIcon from "@digitalservicebund/icons/ThumbUpOutlined";
 import { useFetcher } from "@remix-run/react";
 import { useEffect, useState } from "react";
+import { getTranslationByKey } from "~/util/getTranslationByKey";
+import { useFeedbackTranslations } from "./FeedbackTranslationContext";
 import Button from "../Button";
 import ButtonContainer from "../ButtonContainer";
 import Heading from "../Heading";
 
 export const userRatingFieldname = "wasHelpful";
+const YES_RATING_BUTTON_LABEL_TRANSLATION_KEY = "yes-rating";
+const NO_RATING_BUTTON_LABEL_TRANSLATION_KEY = "no-rating";
 
 export interface RatingBoxProps {
   readonly heading: string;
   readonly url: string;
   readonly context?: string;
-  readonly yesButtonLabel: string;
-  readonly noButtonLabel: string;
 }
 
-export const RatingBox = ({
-  heading,
-  url,
-  context,
-  yesButtonLabel,
-  noButtonLabel,
-}: RatingBoxProps) => {
+export const RatingBox = ({ heading, url, context }: RatingBoxProps) => {
   const ratingFetcher = useFetcher();
   const [jsAvailable, setJsAvailable] = useState(false);
   useEffect(() => setJsAvailable(true), []);
+
+  const { translations } = useFeedbackTranslations();
+
+  const yesButtonLabel = getTranslationByKey(
+    YES_RATING_BUTTON_LABEL_TRANSLATION_KEY,
+    translations,
+  );
+  const noButtonLabel = getTranslationByKey(
+    NO_RATING_BUTTON_LABEL_TRANSLATION_KEY,
+    translations,
+  );
 
   return (
     <>

--- a/app/components/UserFeedback/__test__/FeedbackFormBox.test.tsx
+++ b/app/components/UserFeedback/__test__/FeedbackFormBox.test.tsx
@@ -1,0 +1,36 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render } from "@testing-library/react";
+import { FeedbackFormBox } from "../FeedbackFormBox";
+import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
+
+const HEADING_FEEDBACK = "Heading";
+const ABORT_BUTTON_FEEDBACK = "Abort button";
+const SUBMIT_BUTTON_FEEDBACK = "Submit button";
+
+const TRANSLATION_KEY_RECORD = {
+  "heading-feedback": HEADING_FEEDBACK,
+  "abort-button-feedback": ABORT_BUTTON_FEEDBACK,
+  "submit-button-feedback": SUBMIT_BUTTON_FEEDBACK,
+};
+
+describe("FeedbackFormBox", () => {
+  it("should render the component with the given translations", () => {
+    const FeedbackFormBoxWithRemixStub = createRemixStub([
+      {
+        path: "",
+        Component: () => (
+          <FeedbackTranslationContext.Provider
+            value={{ translations: TRANSLATION_KEY_RECORD }}
+          >
+            <FeedbackFormBox destination="destination" />
+          </FeedbackTranslationContext.Provider>
+        ),
+      },
+    ]);
+    const { getByText } = render(<FeedbackFormBoxWithRemixStub />);
+
+    expect(getByText(HEADING_FEEDBACK)).toBeInTheDocument();
+    expect(getByText(ABORT_BUTTON_FEEDBACK)).toBeInTheDocument();
+    expect(getByText(SUBMIT_BUTTON_FEEDBACK)).toBeInTheDocument();
+  });
+});

--- a/app/components/UserFeedback/__test__/FeedbackFormBox.test.tsx
+++ b/app/components/UserFeedback/__test__/FeedbackFormBox.test.tsx
@@ -1,6 +1,11 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render } from "@testing-library/react";
-import { FeedbackFormBox } from "../FeedbackFormBox";
+import {
+  ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY,
+  FeedbackFormBox,
+  HEADING_FEEDBACK_TRANSLATION_KEY,
+  SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY,
+} from "../FeedbackFormBox";
 import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
 
 const HEADING_FEEDBACK = "Heading";
@@ -8,9 +13,9 @@ const ABORT_BUTTON_FEEDBACK = "Abort button";
 const SUBMIT_BUTTON_FEEDBACK = "Submit button";
 
 const TRANSLATION_KEY_RECORD = {
-  "heading-feedback": HEADING_FEEDBACK,
-  "abort-button-feedback": ABORT_BUTTON_FEEDBACK,
-  "submit-button-feedback": SUBMIT_BUTTON_FEEDBACK,
+  [HEADING_FEEDBACK_TRANSLATION_KEY]: HEADING_FEEDBACK,
+  [ABORT_BUTTON_FEEDBACK_TRANSLATION_KEY]: ABORT_BUTTON_FEEDBACK,
+  [SUBMIT_BUTTON_FEEDBACK_TRANSLATION_KEY]: SUBMIT_BUTTON_FEEDBACK,
 };
 
 describe("FeedbackFormBox", () => {

--- a/app/components/UserFeedback/__test__/PostSubmissionBox.test.tsx
+++ b/app/components/UserFeedback/__test__/PostSubmissionBox.test.tsx
@@ -1,13 +1,17 @@
 import { render } from "@testing-library/react";
 import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
-import { PostSubmissionBox } from "../PostSubmissionBox";
+import {
+  HEADING_POST_SUBMISSION_TRANSLATION_KEY,
+  PostSubmissionBox,
+  TEXT_POST_SUBMISSION_TRANSLATION_KEY,
+} from "../PostSubmissionBox";
 
 const HEADING_POST_SUBMISSION = "Heading";
 const TEXT_POST_SUBMISSION = "Text";
 
 const TRANSLATION_KEY_RECORD = {
-  "heading-post-submission": HEADING_POST_SUBMISSION,
-  "text-post-submission": TEXT_POST_SUBMISSION,
+  [HEADING_POST_SUBMISSION_TRANSLATION_KEY]: HEADING_POST_SUBMISSION,
+  [TEXT_POST_SUBMISSION_TRANSLATION_KEY]: TEXT_POST_SUBMISSION,
 };
 
 describe("PostSubmissionBox", () => {

--- a/app/components/UserFeedback/__test__/PostSubmissionBox.test.tsx
+++ b/app/components/UserFeedback/__test__/PostSubmissionBox.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
+import { PostSubmissionBox } from "../PostSubmissionBox";
+
+const HEADING_POST_SUBMISSION = "Heading";
+const TEXT_POST_SUBMISSION = "Text";
+
+const TRANSLATION_KEY_RECORD = {
+  "heading-post-submission": HEADING_POST_SUBMISSION,
+  "text-post-submission": TEXT_POST_SUBMISSION,
+};
+
+describe("PostSubmissionBox", () => {
+  it("should render the component with the given translations", () => {
+    const { getByText } = render(
+      <FeedbackTranslationContext.Provider
+        value={{ translations: TRANSLATION_KEY_RECORD }}
+      >
+        <PostSubmissionBox />
+      </FeedbackTranslationContext.Provider>,
+    );
+
+    expect(getByText(HEADING_POST_SUBMISSION)).toBeInTheDocument();
+    expect(getByText(TEXT_POST_SUBMISSION)).toBeInTheDocument();
+  });
+});

--- a/app/components/UserFeedback/__test__/RatingBox.test.tsx
+++ b/app/components/UserFeedback/__test__/RatingBox.test.tsx
@@ -1,0 +1,33 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render } from "@testing-library/react";
+import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
+import { RatingBox } from "../RatingBox";
+
+const YES_RATING = "yes";
+const NO_RATING = "no";
+
+const TRANSLATION_KEY_RECORD = {
+  "yes-rating": YES_RATING,
+  "no-rating": NO_RATING,
+};
+
+describe("RatingBox", () => {
+  it("should render the component with the given translations", () => {
+    const RatingBoxWithRemixStub = createRemixStub([
+      {
+        path: "",
+        Component: () => (
+          <FeedbackTranslationContext.Provider
+            value={{ translations: TRANSLATION_KEY_RECORD }}
+          >
+            <RatingBox heading="heading" url="url" />
+          </FeedbackTranslationContext.Provider>
+        ),
+      },
+    ]);
+    const { getByText } = render(<RatingBoxWithRemixStub />);
+
+    expect(getByText(YES_RATING)).toBeInTheDocument();
+    expect(getByText(NO_RATING)).toBeInTheDocument();
+  });
+});

--- a/app/components/UserFeedback/__test__/RatingBox.test.tsx
+++ b/app/components/UserFeedback/__test__/RatingBox.test.tsx
@@ -1,14 +1,18 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render } from "@testing-library/react";
 import { FeedbackTranslationContext } from "../FeedbackTranslationContext";
-import { RatingBox } from "../RatingBox";
+import {
+  NO_RATING_BUTTON_LABEL_TRANSLATION_KEY,
+  RatingBox,
+  YES_RATING_BUTTON_LABEL_TRANSLATION_KEY,
+} from "../RatingBox";
 
 const YES_RATING = "yes";
 const NO_RATING = "no";
 
 const TRANSLATION_KEY_RECORD = {
-  "yes-rating": YES_RATING,
-  "no-rating": NO_RATING,
+  [YES_RATING_BUTTON_LABEL_TRANSLATION_KEY]: YES_RATING,
+  [NO_RATING_BUTTON_LABEL_TRANSLATION_KEY]: NO_RATING,
 };
 
 describe("RatingBox", () => {

--- a/app/components/UserFeedback/__test__/UserFeedback.test.tsx
+++ b/app/components/UserFeedback/__test__/UserFeedback.test.tsx
@@ -9,19 +9,7 @@ describe("UserFeedback", () => {
   const mockedProps = {
     rating: {
       heading: "heading",
-      yesButtonLabel: "Ja",
-      noButtonLabel: "Nein",
       context: "flowId",
-    },
-    feedback: {
-      heading: "heading",
-      placeholder: "placeholder",
-      abortButtonLabel: "cancel",
-      submitButtonLabel: "submit",
-    },
-    postSubmission: {
-      heading: "heading",
-      text: "text",
     },
   };
 

--- a/app/components/UserFeedback/index.tsx
+++ b/app/components/UserFeedback/index.tsx
@@ -1,9 +1,6 @@
 import { useLocation } from "@remix-run/react";
-import { type FeedbackBoxProps, FeedbackFormBox } from "./FeedbackFormBox";
-import {
-  type PostSubmissionBoxProps,
-  PostSubmissionBox,
-} from "./PostSubmissionBox";
+import { FeedbackFormBox } from "./FeedbackFormBox";
+import { PostSubmissionBox } from "./PostSubmissionBox";
 import { type RatingBoxProps, RatingBox } from "./RatingBox";
 import Background from "../Background";
 import Container from "../Container";
@@ -17,8 +14,6 @@ export enum BannerState {
 type UserFeedbackProps = {
   bannerState: BannerState;
   rating: Omit<RatingBoxProps, "url">;
-  feedback: Omit<FeedbackBoxProps, "destination">;
-  postSubmission: PostSubmissionBoxProps;
 };
 
 export const USER_FEEDBACK_ID = "user-feedback-banner";
@@ -45,11 +40,9 @@ export default function UserFeedback(props: Readonly<UserFeedbackProps>) {
                 <RatingBox url={pathname} {...props.rating} />
               ),
               [BannerState.ShowFeedback]: (
-                <FeedbackFormBox destination={pathname} {...props.feedback} />
+                <FeedbackFormBox destination={pathname} />
               ),
-              [BannerState.FeedbackGiven]: (
-                <PostSubmissionBox {...props.postSubmission} />
-              ),
+              [BannerState.FeedbackGiven]: <PostSubmissionBox />,
             }[props.bannerState]
           }
         </div>

--- a/app/components/resultPage/ResultPage.tsx
+++ b/app/components/resultPage/ResultPage.tsx
@@ -178,19 +178,7 @@ export function ResultPage({
           bannerState={bannerState}
           rating={{
             heading: "Hat Ihnen der Vorab-Check geholfen?",
-            yesButtonLabel: "Ja",
-            noButtonLabel: "Nein",
             context: flowId,
-          }}
-          feedback={{
-            heading: "Was können wir verbessern?",
-            placeholder: "Bitte tragen Sie keine persönlichen Daten ein!",
-            abortButtonLabel: "Abbrechen",
-            submitButtonLabel: "Abschicken",
-          }}
-          postSubmission={{
-            heading: "Vielen Dank!",
-            text: "Ihr Feedback hilft uns, diese Seite für alle Nutzenden zu verbessern!",
           }}
         />
       </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -32,6 +32,7 @@ import { CookieBanner } from "./components/CookieBanner";
 import FeedbackBanner, { augmentFeedback } from "./components/FeedbackBanner";
 import Footer from "./components/Footer";
 import Header from "./components/PageHeader";
+import { FeedbackTranslationContext } from "./components/UserFeedback/FeedbackTranslationContext";
 import { getCookieBannerProps } from "./services/cms/models/StrapiCookieBannerSchema";
 import { getFooterProps } from "./services/cms/models/StrapiFooter";
 import { getStrapiFeedback } from "./services/cms/models/StrapiGlobal";
@@ -95,6 +96,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     meta,
     deleteDataStrings,
     hasAnyUserData,
+    feedbackTranslations,
   ] = await Promise.all([
     fetchSingleEntry("page-header"),
     fetchSingleEntry("global"),
@@ -105,6 +107,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     fetchMeta({ filterValue: "/" }),
     fetchTranslations("delete-data"),
     anyUserData(request),
+    fetchTranslations("feedback"),
   ]);
 
   return json({
@@ -118,6 +121,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     context,
     deletionLabel: deleteDataStrings["footerLinkLabel"],
     hasAnyUserData,
+    feedbackTranslations,
   });
 };
 
@@ -130,6 +134,7 @@ function App() {
     feedback,
     deletionLabel,
     hasAnyUserData,
+    feedbackTranslations,
   } = useLoaderData<typeof loader>();
   const { breadcrumbs, title, ogTitle, description } =
     metaFromMatches(useMatches());
@@ -187,9 +192,13 @@ function App() {
         />
         <Header {...header} />
         <Breadcrumbs breadcrumbs={breadcrumbs} />
-        <main className="flex-grow">
-          <Outlet />
-        </main>
+        <FeedbackTranslationContext.Provider
+          value={{ translations: feedbackTranslations }}
+        >
+          <main className="flex-grow">
+            <Outlet />
+          </main>
+        </FeedbackTranslationContext.Provider>
         <footer>
           <FeedbackBanner {...augmentFeedback(feedback, title)} />
           <Footer

--- a/stories/UserFeedback.stories.tsx
+++ b/stories/UserFeedback.stories.tsx
@@ -18,18 +18,6 @@ export const Example: StoryObj<typeof meta> = {
     bannerState: BannerState.ShowRating,
     rating: {
       heading: "Hat Ihnen der Vorab-Check geholfen?",
-      yesButtonLabel: "Ja",
-      noButtonLabel: "Nein",
-    },
-    feedback: {
-      heading: "Haben sie Verbesserungsvorschläge",
-      placeholder: "Bitte tragen Sie keine persönlichen Daten ein!",
-      abortButtonLabel: "Abbrechen",
-      submitButtonLabel: "Abschicken",
-    },
-    postSubmission: {
-      heading: "Vielen Dank!",
-      text: "Ihr Feedback hilft uns, diese Seite für alle Nutzenden zu verbessern!",
     },
   },
   decorators: [(Story) => remixContext(Story)],


### PR DESCRIPTION
### Add translations for the User feedback component

Today we have hardcode the texts/descriptions of the User feedback component. We are moving those texts/descriptions to Strapi Translations

### Proposal

- Move texts/descriptions to Strapi Translation
- Create a context with the feedback translations
- Use hook to get the feedback translations without pass them via props

### Out of scope
Later we will have this component also in Strapi, so using the context and hook it would be easier to make the component following the Product and UX requirements

