### PR TITLE
Add Standalone Link Component

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -3,7 +3,9 @@ import { cloneElement, type ReactElement } from "react";
 import { z } from "zod";
 import { isExternalUrl, isFileDowloadUrl } from "~/util/url";
 
-const iconSchema = z.custom<ReactElement<{ className: string }>>().optional();
+export const iconSchema = z
+  .custom<ReactElement<{ className: string }>>()
+  .optional();
 
 export const ButtonPropsSchema = z.object({
   text: z.string().optional(),

--- a/app/components/CourtDetails.tsx
+++ b/app/components/CourtDetails.tsx
@@ -1,5 +1,5 @@
 import { normalizeURL } from "~/util/strings";
-import { OpenInNewTabIcon } from "./openInNewTabIcon";
+import { StandaloneLink } from "./StandaloneLink";
 
 type CourtDetailsProps = {
   name: string;
@@ -38,14 +38,10 @@ const CourtDetails = ({
           <li>
             <h3 className="sr-only">{websiteLabel}</h3>
             <p>
-              <a
-                href={normalizeURL(website)}
-                rel="noreferrer"
-                target="_blank"
-                className="text-link"
-              >
-                {websiteLabel} {name} <OpenInNewTabIcon />
-              </a>
+              <StandaloneLink
+                url={normalizeURL(website)}
+                text={`${websiteLabel} ${name}`}
+              />
             </p>
           </li>
         )}

--- a/app/components/StandaloneLink.tsx
+++ b/app/components/StandaloneLink.tsx
@@ -1,40 +1,17 @@
-import classNames from "classnames";
-import { z } from "zod";
-import { iconSchema } from "./Button";
+import { isExternalUrl } from "~/util/url";
 import { OpenInNewTabIcon } from "./openInNewTabIcon";
-import { isExternalUrl } from "../util/url";
 
-export const StandaloneLinkPropsSchema = z.object({
-  id: z.number().optional(),
-  url: z.string(),
-  text: z.string(),
-  icon: iconSchema.optional(),
-  look: z
-    .enum([
-      "ds-label-01-reg",
-      "ds-label-01-bold",
-      "ds-label-02-reg",
-      "ds-label-02-bold",
-      "ds-label-03-reg",
-      "ds-label-03-bold",
-    ])
-    .optional(),
-});
+type StandaloneLinkProps = Readonly<{
+  url: string;
+  text: string;
+  icon?: React.ReactNode;
+}>;
 
-type StandaloneLinkProps = z.input<typeof StandaloneLinkPropsSchema>;
-
-export const StandaloneLink = ({
-  id,
-  url,
-  text,
-  icon,
-  look,
-}: StandaloneLinkProps) => {
+export const StandaloneLink = ({ url, text, icon }: StandaloneLinkProps) => {
   const isExternal = isExternalUrl(url);
   const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
-    id: id?.toString(),
     href: url,
-    className: classNames("text-link", look),
+    className: "text-link",
     ...(isExternal
       ? { target: "_blank", rel: "noreferrer", title: "öffnet neues Fenster" }
       : {}),

--- a/app/components/StandaloneLink.tsx
+++ b/app/components/StandaloneLink.tsx
@@ -1,0 +1,50 @@
+import classNames from "classnames";
+import { z } from "zod";
+import { iconSchema } from "./Button";
+import { OpenInNewTabIcon } from "./openInNewTabIcon";
+import { isExternalUrl } from "../util/url";
+
+export const StandaloneLinkPropsSchema = z.object({
+  id: z.number().optional(),
+  url: z.string(),
+  text: z.string(),
+  icon: iconSchema.optional(),
+  look: z
+    .enum([
+      "ds-label-01-reg",
+      "ds-label-01-bold",
+      "ds-label-02-reg",
+      "ds-label-02-bold",
+      "ds-label-03-reg",
+      "ds-label-03-bold",
+    ])
+    .optional(),
+});
+
+type StandaloneLinkProps = z.input<typeof StandaloneLinkPropsSchema>;
+
+export const StandaloneLink = ({
+  id,
+  url,
+  text,
+  icon,
+  look,
+}: StandaloneLinkProps) => {
+  const isExternal = isExternalUrl(url);
+  const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    id: id?.toString(),
+    href: url,
+    className: classNames("text-link", look),
+    ...(isExternal
+      ? { target: "_blank", rel: "noreferrer", title: "öffnet neues Fenster" }
+      : {}),
+  };
+
+  return (
+    <a {...anchorProps}>
+      {icon}
+      {text}
+      {isExternal && <OpenInNewTabIcon />}
+    </a>
+  );
+};

--- a/app/components/__test__/StandaloneLink.test.tsx
+++ b/app/components/__test__/StandaloneLink.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { StandaloneLink } from "../StandaloneLink";
+
+describe("Standalone Button Component", () => {
+  test("Displays an external link", () => {
+    render(
+      <StandaloneLink url={"https://blank.blank"} text={"External Link"} />,
+    );
+    expect(screen.getByText("External Link")).toBeInTheDocument();
+    expect(screen.getByTestId("OpenInNewIcon")).toBeInTheDocument();
+    expect(screen.getByTitle("öffnet neues Fenster")).toBeInTheDocument();
+  });
+
+  test("Displays no icon if the input link isn't external", () => {
+    render(<StandaloneLink url={"/home"} text={"Internal Link"} />);
+    expect(screen.queryByTestId("OpenInNewIcon")).not.toBeInTheDocument();
+  });
+
+  test("Displays a custom icon", () => {
+    render(
+      <StandaloneLink
+        url={"/home"}
+        text={"Internal Link, custom icon"}
+        icon={<p>Hello World</p>}
+      />,
+    );
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+
+  test("Link can have custom styling", () => {
+    render(
+      <StandaloneLink
+        url={"/home"}
+        text={"Internal Link, custom styling"}
+        look={"ds-label-03-bold"}
+      />,
+    );
+    expect(screen.getByText("Internal Link, custom styling")).toHaveClass(
+      "ds-label-03-bold",
+    );
+  });
+});

--- a/app/components/__test__/StandaloneLink.test.tsx
+++ b/app/components/__test__/StandaloneLink.test.tsx
@@ -26,17 +26,4 @@ describe("Standalone Button Component", () => {
     );
     expect(screen.getByText("Hello World")).toBeInTheDocument();
   });
-
-  test("Link can have custom styling", () => {
-    render(
-      <StandaloneLink
-        url={"/home"}
-        text={"Internal Link, custom styling"}
-        look={"ds-label-03-bold"}
-      />,
-    );
-    expect(screen.getByText("Internal Link, custom styling")).toHaveClass(
-      "ds-label-03-bold",
-    );
-  });
 });

--- a/app/services/openSourceLicenses/LicenseList.tsx
+++ b/app/services/openSourceLicenses/LicenseList.tsx
@@ -1,19 +1,11 @@
-import { OpenInNewTabIcon } from "~/components/openInNewTabIcon";
 import type { Dependency } from "./generate.server";
+import { StandaloneLink } from "../../components/StandaloneLink";
 
 const renderLicenseEntry = (dependencyString: string, infos: Dependency) => {
   return (
     <li key={dependencyString}>
       {infos.repository ? (
-        <a
-          href={infos.repository}
-          className="text-link"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {dependencyString}
-          <OpenInNewTabIcon />
-        </a>
+        <StandaloneLink url={infos.repository} text={dependencyString} />
       ) : (
         dependencyString
       )}

--- a/stories/StandaloneLink.stories.tsx
+++ b/stories/StandaloneLink.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StandaloneLink } from "../app/components/StandaloneLink";
+import { remixContext } from "../.storybook/remixContext";
+const component = StandaloneLink;
+
+const meta = {
+  title: "Component/StandaloneLink",
+  component: component,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof component>;
+
+export const Default = {
+  args: {
+    text: "External Link",
+    url: "https://www.google.com",
+  },
+  decorators: [(Story) => remixContext(Story)],
+} satisfies StoryObj<typeof meta>;
+export default meta;

--- a/stories/StandaloneLink.stories.tsx
+++ b/stories/StandaloneLink.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { StandaloneLink } from "../app/components/StandaloneLink";
 import { remixContext } from "../.storybook/remixContext";
+import SignLanguage from "@digitalservicebund/icons/SignLanguage";
+
 const component = StandaloneLink;
 
 const meta = {
@@ -17,4 +19,22 @@ export const Default = {
   },
   decorators: [(Story) => remixContext(Story)],
 } satisfies StoryObj<typeof meta>;
+
+export const InternalLeftIcon = {
+  args: {
+    text: "Internal Link with Left Icon",
+    url: "/home",
+    icon: SignLanguage({
+      height: "1.2em",
+      width: "1.2em",
+      style: {
+        display: "inline-block",
+        marginRight: "0.2em",
+        marginBottom: "4px",
+      },
+    }),
+  },
+  decorators: [(Story) => remixContext(Story)],
+} satisfies StoryObj<typeof meta>;
+
 export default meta;


### PR DESCRIPTION
My very first contribution 🎉 🥳 

This PR adds the Standalone Link component, as well as Storybook and tests.

https://app.asana.com/0/1203259475859667/1207931106219834/f

Demo: (Visually identical 😆 )
<img width="629" alt="Bildschirmfoto 2024-08-07 um 15 02 23" src="https://github.com/user-attachments/assets/092b7b2e-75c7-4cd6-a9e7-ad1fac417e77">

Demo: (Left Icon added)
![image](https://github.com/user-attachments/assets/46cc4971-7790-4bdc-a177-b49fd9caf79d)
