### PR TITLE
Fix input to large devices

### DIFF
--- a/app/components/inputs/__test__/Input.test.tsx
+++ b/app/components/inputs/__test__/Input.test.tsx
@@ -27,19 +27,19 @@ afterEach(() => {
 
 describe("Input", () => {
   const cases = [
-    { widthProps: "3", expectedClassWidth: "w-[9ch]" },
-    { widthProps: "5", expectedClassWidth: "w-[11ch]" },
-    { widthProps: "7", expectedClassWidth: "w-[13ch]" },
-    { widthProps: "10", expectedClassWidth: "w-[16ch]" },
-    { widthProps: "16", expectedClassWidth: "w-[22ch]" },
-    { widthProps: "24", expectedClassWidth: "w-[30ch]" },
+    { widthProps: "3", expectedClassWidth: "max-w-[9ch]" },
+    { widthProps: "5", expectedClassWidth: "max-w-[11ch]" },
+    { widthProps: "7", expectedClassWidth: "max-w-[13ch]" },
+    { widthProps: "10", expectedClassWidth: "max-w-[16ch]" },
+    { widthProps: "16", expectedClassWidth: "max-w-[22ch]" },
+    { widthProps: "24", expectedClassWidth: "max-w-[30ch]" },
     {
       widthProps: "36",
-      expectedClassWidth: "w-[42ch] max-sm:w-full",
+      expectedClassWidth: "max-w-[42ch]",
     },
     {
       widthProps: "54",
-      expectedClassWidth: "w-[60ch] max-lg:w-full",
+      expectedClassWidth: "max-w-[60ch]",
     },
   ];
 

--- a/app/components/inputs/__test__/Input.test.tsx
+++ b/app/components/inputs/__test__/Input.test.tsx
@@ -35,11 +35,11 @@ describe("Input", () => {
     { widthProps: "24", expectedClassWidth: "w-[30ch]" },
     {
       widthProps: "36",
-      expectedClassWidth: "w-[42ch] ds-input-select-width-54-36",
+      expectedClassWidth: "w-[42ch] max-sm:w-full",
     },
     {
       widthProps: "54",
-      expectedClassWidth: "w-[60ch] ds-input-select-width-54-36",
+      expectedClassWidth: "w-[60ch] max-lg:w-full",
     },
   ];
 

--- a/app/components/inputs/__test__/Select.test.tsx
+++ b/app/components/inputs/__test__/Select.test.tsx
@@ -27,15 +27,15 @@ afterEach(() => {
 
 describe("Select", () => {
   const cases = [
-    { widthProps: "16", expectedClassWidth: "w-[22ch]" },
-    { widthProps: "24", expectedClassWidth: "w-[30ch]" },
+    { widthProps: "16", expectedClassWidth: "max-w-[22ch]" },
+    { widthProps: "24", expectedClassWidth: "max-w-[30ch]" },
     {
       widthProps: "36",
-      expectedClassWidth: "w-[42ch] max-sm:w-full",
+      expectedClassWidth: "max-w-[42ch]",
     },
     {
       widthProps: "54",
-      expectedClassWidth: "w-[60ch] max-lg:w-full",
+      expectedClassWidth: "max-w-[60ch]",
     },
   ];
 

--- a/app/components/inputs/__test__/Select.test.tsx
+++ b/app/components/inputs/__test__/Select.test.tsx
@@ -31,11 +31,11 @@ describe("Select", () => {
     { widthProps: "24", expectedClassWidth: "w-[30ch]" },
     {
       widthProps: "36",
-      expectedClassWidth: "w-[42ch] ds-input-select-width-54-36",
+      expectedClassWidth: "w-[42ch] max-sm:w-full",
     },
     {
       widthProps: "54",
-      expectedClassWidth: "w-[60ch] ds-input-select-width-54-36",
+      expectedClassWidth: "w-[60ch] max-lg:w-full",
     },
   ];
 

--- a/app/components/inputs/width.ts
+++ b/app/components/inputs/width.ts
@@ -9,6 +9,6 @@ export const widthClassname = (width: FieldWidth | undefined) =>
     "10": "w-[16ch]",
     "16": "w-[22ch]",
     "24": "w-[30ch]",
-    "36": "w-[42ch] ds-input-select-width-54-36",
-    "54": "w-[60ch] ds-input-select-width-54-36",
+    "36": "w-[42ch] max-sm:w-full",
+    "54": "w-[60ch] max-lg:w-full",
   })[width ?? ""];

--- a/app/components/inputs/width.ts
+++ b/app/components/inputs/width.ts
@@ -3,12 +3,12 @@ export type FieldWidth = "3" | "5" | "7" | "10" | "16" | "24" | "36" | "54";
 export const widthClassname = (width: FieldWidth | undefined) =>
   ({
     "": undefined,
-    "3": "w-[9ch]",
-    "5": "w-[11ch]",
-    "7": "w-[13ch]",
-    "10": "w-[16ch]",
-    "16": "w-[22ch]",
-    "24": "w-[30ch]",
-    "36": "w-[42ch] max-sm:w-full",
-    "54": "w-[60ch] max-lg:w-full",
+    "3": "max-w-[9ch]",
+    "5": "max-w-[11ch]",
+    "7": "max-w-[13ch]",
+    "10": "max-w-[16ch]",
+    "16": "max-w-[22ch]",
+    "24": "max-w-[30ch]",
+    "36": "max-w-[42ch]",
+    "54": "max-w-[60ch]",
   })[width ?? ""];

--- a/app/routes/shared/components/FormFlowPage.tsx
+++ b/app/routes/shared/components/FormFlowPage.tsx
@@ -44,7 +44,7 @@ export function FormFlowPage() {
           />
         </div>
         <div
-          className={`ds-stack-40 container md:flex-1 ${navItems && "!ml-0"}`}
+          className={`ds-stack-40 container md:flex-1 ${navItems && "!ml-0 !mr-0"}`}
         >
           <div className="ds-stack-16">
             {preHeading && <p className="ds-label-01-bold">{preHeading}</p>}

--- a/app/styles.css
+++ b/app/styles.css
@@ -275,10 +275,3 @@ svg {
 .auto-suggest-input-disabled {
   box-shadow: none;
 }
-
-/* on mobile, input and select should have 100% width when in strapi is selected characters54 or characters36 */
-@media (max-width: 499px) {
-  .ds-input-select-width-54-36 {
-    width: 100%;
-  }
-}


### PR DESCRIPTION
### Problem
On the Formular pages for mobile and tables, when an input is selected 54 characters, it jumps to the bottom of the page.

![image](https://github.com/user-attachments/assets/aaf89d4b-1e89-48c3-9d0b-3b63e23679fe)

More info in the following slack [link](https://digitalservicebund.slack.com/archives/C044NUG2468/p1726160178710569)

### Solution
Change width to max-width