### PR TITLE
fix(List links bullet point styling)

### DIFF
--- a/app/components/StandaloneLink.tsx
+++ b/app/components/StandaloneLink.tsx
@@ -23,7 +23,7 @@ export const StandaloneLink = ({
   const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
     href: url,
     "aria-label": text,
-    className: classNames("text-link min-h-[24px] inline-block", className),
+    className: classNames("text-link min-h-[24px]", className),
     ...(shouldOpenNewTab
       ? {
           "aria-label": `${text}, ${OPEN_NEW_TAB}`,

--- a/app/components/__test__/StandaloneLink.test.tsx
+++ b/app/components/__test__/StandaloneLink.test.tsx
@@ -74,7 +74,6 @@ describe("Standalone Button Component", () => {
 
   test("Render className with iniline-block and min-height", () => {
     render(<StandaloneLink url={"/home"} text={"Internal Link"} />);
-    expect(screen.getByText("Internal Link")).toHaveClass("inline-block");
     expect(screen.getByText("Internal Link")).toHaveClass("min-h-[24px]");
   });
 });


### PR DESCRIPTION
This PR fixes a styling bug where link list items with a newline would display the bullet point at the bottom, instead of at the top, of the list item.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208311653825044