### PR TITLE
feat(scripts): npm run verify:unusedStrapiEntries

### DIFF
--- a/app/services/validation/postcode.ts
+++ b/app/services/validation/postcode.ts
@@ -7,9 +7,11 @@ function isValidPostcode(postcode: string) {
   return postcodeNum >= 1067 && postcodeNum <= 99998 && /\d{5}/.test(postcode);
 }
 
-const serverValidation = serverOnly$((postcode: string) =>
-  validPostcodes.has(postcode),
-);
+// The unusual "import.meta.env &&" logic is used to allow tsx scripts to consume serverOnly$() without running vite, see https://github.com/pcattori/vite-env-only/issues/19
+// At the time of writing, 'scripts/unusedStrapiEntries.ts' imports { flows } from "~/flows/flows.server", which then pulls in the schema below
+const serverValidation =
+  import.meta.env &&
+  serverOnly$((postcode: string) => validPostcodes.has(postcode));
 
 export const postcodeSchema = z
   .string()

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "update:courtData": "tsx ./app/services/gerichtsfinder/encryptedStorage.ts updateZip",
     "update:URLs": "tsx ./app/services/gerichtsfinder/checkURLs.ts checkURLs",
     "verify:emails": "tsx ./scripts/verifyExternalLinks.ts verifyEmails",
+    "verify:unusedStrapiEntries": "tsx ./scripts/unusedStrapiEntries.ts unusedStrapiEntry",
     "verify:websites": "tsx ./scripts/verifyExternalLinks.ts verifyWebsites"
   },
   "dependencies": {

--- a/scripts/unusedStrapiEntries.ts
+++ b/scripts/unusedStrapiEntries.ts
@@ -45,6 +45,10 @@ function partitionPagesByStepId(pages: MinimalPage[]) {
   return _.partition(pages, (page) => page.attributes.stepId !== null);
 }
 
+function partitionPagesByFlowId(pages: MinimalPage[]) {
+  return _.partition(pages, (page) => page.attributes.flow_ids.data.length > 0);
+}
+
 async function unusedStrapiEntry() {
   let content: StrapiSchemas | undefined = undefined;
   try {
@@ -77,6 +81,19 @@ async function unusedStrapiEntry() {
         page,
       );
     });
+  } else {
+    console.log("No entries without stepIds ✅");
+  }
+
+  const [_pagesWithFlowIds, pagesWithoutFlowIds] =
+    partitionPagesByFlowId(pages);
+  if (pagesWithoutFlowIds.length > 0) {
+    console.warn(`Found ${pagesWithoutFlowIds.length} pages without flowIds:`);
+    pagesWithoutFlowIds.forEach((page) => {
+      console.warn(page);
+    });
+  } else {
+    console.log("No entries without flowIds ✅");
   }
 
   const allUrlsFromXstateConfigs = Object.entries(flows).flatMap(

--- a/scripts/unusedStrapiEntries.ts
+++ b/scripts/unusedStrapiEntries.ts
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+import { readFileSync } from "node:fs";
+import _ from "lodash";
+import { flows } from "~/flows/flows.server";
+import { strapiFileSchema, type StrapiSchemas } from "~/services/cms/schemas";
+import { type Config } from "~/services/flow/server/buildFlowController";
+
+const contentFilePath = "./content.json";
+
+type MinimalPage = {
+  attributes: {
+    flow_ids: StrapiSchemas["form-flow-pages"][0]["attributes"]["flow_ids"];
+    stepId: StrapiSchemas["form-flow-pages"][0]["attributes"]["stepId"];
+  };
+};
+
+// recursivly traverse states object, while concatenating nested names. Returns a flat list
+function allStateNames(xstateConfigStates: Config["states"]): string[] {
+  if (!xstateConfigStates) return [];
+  return Object.entries(xstateConfigStates).flatMap(
+    ([stateName, stateConfig]) => {
+      if (stateConfig.states) {
+        // there are nested states -> recursion
+        return allStateNames(stateConfig.states).map(
+          (subStateName) => stateName + "/" + subStateName,
+        );
+      } else {
+        // stepId in xstate config use ergebnis/ prefix to indicate ErgebnisPage
+        return stateName.replace("ergebnis/", "");
+      }
+    },
+  );
+}
+
+function urlsFromPages(pages: MinimalPage[]) {
+  // A page containing multiple flowIDs results in multiple URLs
+  return pages.flatMap((page) =>
+    page.attributes.flow_ids.data.map(
+      (flowId) => flowId.attributes.flowId + page.attributes.stepId,
+    ),
+  );
+}
+
+function partitionPagesByStepId(pages: MinimalPage[]) {
+  return _.partition(pages, (page) => page.attributes.stepId !== null);
+}
+
+async function unusedStrapiEntry() {
+  let content: StrapiSchemas | undefined = undefined;
+  try {
+    content = strapiFileSchema.parse(
+      JSON.parse(readFileSync(contentFilePath, "utf-8")),
+    );
+    console.log("Content imported successfully, scanning...");
+  } catch (error) {
+    console.error(error);
+    console.warn(
+      `The previous error occured while trying to read ${contentFilePath}. Did you forget to run 'npm run build:localContent' before?`,
+    );
+    process.exit(1);
+  }
+
+  const pages = [
+    ...content["form-flow-pages"],
+    ...content["vorab-check-pages"],
+    ...content["result-pages"],
+  ];
+
+  const [pagesWithStepId, pagesWithoutStepId] = partitionPagesByStepId(pages);
+
+  if (pagesWithoutStepId.length > 0) {
+    console.warn(
+      `Found ${pagesWithoutStepId.length} pages without stepId: `,
+      pagesWithoutStepId,
+    );
+  }
+
+  const allUrlsFromXstateConfigs = Object.entries(flows).flatMap(
+    ([flowId, { config }]) =>
+      allStateNames(config.states).map((stateName) => `${flowId}/${stateName}`),
+  );
+
+  const unusedUrls = urlsFromPages(pagesWithStepId).filter(
+    (url) => !allUrlsFromXstateConfigs.includes(url),
+  );
+
+  console.log(`Found ${unusedUrls.length} unused strapi entries: `, unusedUrls);
+}
+
+if (process.argv[2] === "unusedStrapiEntry") unusedStrapiEntry();

--- a/scripts/unusedStrapiEntries.ts
+++ b/scripts/unusedStrapiEntries.ts
@@ -69,10 +69,14 @@ async function unusedStrapiEntry() {
   const [pagesWithStepId, pagesWithoutStepId] = partitionPagesByStepId(pages);
 
   if (pagesWithoutStepId.length > 0) {
-    console.warn(
-      `Found ${pagesWithoutStepId.length} pages without stepId: `,
-      pagesWithoutStepId,
-    );
+    console.warn(`Found ${pagesWithoutStepId.length} pages without stepId:`);
+    pagesWithoutStepId.forEach((page) => {
+      console.warn(
+        "FlowIds: ",
+        page.attributes.flow_ids.data.map((flowId) => flowId.attributes.flowId),
+        page,
+      );
+    });
   }
 
   const allUrlsFromXstateConfigs = Object.entries(flows).flatMap(


### PR DESCRIPTION
https://app.asana.com/0/1203259475859667/1208196006606406/f

- scans all xstate configs to recursively build URLs
- parses URLs from all form-flow-, vorabcheck-, result-pages (from content file)
- compares and returns all URLs that aren't referenced in xstate configs
- additionally prints pages without stepId