### PR TITLE
Both streams: Remove accessibility tests of forms flow pages

### DIFF
--- a/tests/e2e/flowPages/beratungshilfe/formular/anwaltlicheVertretung.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/anwaltlicheVertretung.ts
@@ -1,6 +1,5 @@
 import { type Page } from "@playwright/test";
 import type { BeratungshilfeFormular } from "tests/e2e/pom/BeratungshilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 import { today, toGermanDateFormat } from "~/util/date";
 
 export async function startAnwaltlicheVertretung(
@@ -8,27 +7,21 @@ export async function startAnwaltlicheVertretung(
   beratungshilfeFormular: BeratungshilfeFormular,
 ) {
   // beratungshilfe/antrag/anwaltliche-vertretung/start
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("anwaltskanzlei", "yes");
 
   // beratungshilfe/antrag/anwaltliche-vertretung/beratung-stattgefunden
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("beratungStattgefunden", "yes");
 
   // beratungshilfe/antrag/anwaltliche-vertretung/beratung-stattgefunden-datum
-  await expectPageToBeAccessible({ page });
-
   await beratungshilfeFormular.fillInputPage(
     "beratungStattgefundenDatum",
     toGermanDateFormat(today()),
   );
 
   // beratungshilfe/antrag/anwaltliche-vertretung/frist-hinweis
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/anwaltliche-vertretung/anwalt-kontaktdaten
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInput(
     "anwaltName",
     "Leonardo Da Musterfrau",

--- a/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenAusgaben.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenAusgaben.ts
@@ -1,12 +1,10 @@
 import type { Page } from "@playwright/test";
 import type { BeratungshilfeFormular } from "tests/e2e/pom/BeratungshilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenAusgaben(
   page: Page,
   beratungshilfeFormular: BeratungshilfeFormular,
 ) {
   // beratungshilfe/antrag/finanzielle-angaben/ausgaben/ausgaben-frage
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("hasAusgaben", "no");
 }

--- a/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenEigentum.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenEigentum.ts
@@ -1,40 +1,31 @@
 import type { Page } from "@playwright/test";
 import type { BeratungshilfeFormular } from "tests/e2e/pom/BeratungshilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenEigentum(
   page: Page,
   formular: BeratungshilfeFormular,
 ) {
   // /finanzielle-angaben/eigentum/eigentum-info
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /finanzielle-angaben/eigentum/heirat-info
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /finanzielle-angaben/eigentum/bankkonten-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasBankkonto", "yes");
 
   // /finanzielle-angaben/eigentum/geldanlagen-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasGeldanlage", "yes");
 
   // /finanzielle-angaben/eigentum/wertsachen-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasWertsache", "yes");
 
   // /finanzielle-angaben/eigentum/grundeigentum-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasGrundeigentum", "yes");
 
   // /finanzielle-angaben/eigentum/kraftfahrzeuge-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasKraftfahrzeug", "yes");
 
   // /finanzielle-angaben/eigentum/gesamtwert
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("eigentumTotalWorth", "more10000");
 }

--- a/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenEinkommen.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenEinkommen.ts
@@ -1,6 +1,5 @@
 import type { Page } from "@playwright/test";
 import type { BeratungshilfeFormular } from "tests/e2e/pom/BeratungshilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenEinkommen(
   page: Page,
@@ -10,32 +9,26 @@ export async function startFinanzielleAngabenEinkommen(
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/staatliche-leistungen
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("staatlicheLeistungen", "keine");
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/erwerbstaetig
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("erwerbstaetig", "yes");
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/art
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillCheckboxesPage(
     "berufart.selbststaendig",
     "berufart.festangestellt",
   );
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/situation
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("berufsituation", "student");
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/weiteres-einkommen
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillCheckboxesPage(
     "weitereseinkommen.unterhaltszahlungen",
     "weitereseinkommen.wohngeld",
   );
 
   // beratungshilfe/antrag/finanzielle-angaben/einkommen/weiteres-einkommen
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInputPage("einkommen", "100");
 }

--- a/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenWohnung.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/finanzielleAngabenWohnung.ts
@@ -1,6 +1,5 @@
 import type { Page } from "@playwright/test";
 import type { BeratungshilfeFormular } from "tests/e2e/pom/BeratungshilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenWohnung(
   page: Page,
@@ -16,7 +15,6 @@ export async function startFinanzielleAngabenWohnung(
   ];
 
   for await (const callback of stepCallbacks) {
-    await expectPageToBeAccessible({ page });
     await callback();
   }
 }

--- a/tests/e2e/flowPages/beratungshilfe/formular/grundvoraussetzungen.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/grundvoraussetzungen.ts
@@ -11,27 +11,21 @@ export async function startGrundvoraussetzungen(
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/grundvoraussetzungen/rechtsschutzversicherung
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("rechtsschutzversicherung", "no");
 
   // beratungshilfe/antrag/grundvoraussetzungen/wurde-verklagt
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("wurdeVerklagt", "no");
 
   // beratungshilfe/antrag/grundvoraussetzungen/klage-eingereicht
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("klageEingereicht", "no");
 
   // beratungshilfe/antrag/grundvoraussetzungen/hamburg-oder-bremen
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("hamburgOderBremen", "no");
 
   // beratungshilfe/antrag/grundvoraussetzungen/beratungshilfe-beantragt
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("beratungshilfeBeantragt", "no");
 
   // beratungshilfe/antrag/grundvoraussetzungen/eigeninitiative-grundvorraussetzung
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage(
     "eigeninitiativeGrundvorraussetzung",
     "no",

--- a/tests/e2e/flowPages/beratungshilfe/formular/persoenlicheDaten.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/persoenlicheDaten.ts
@@ -11,17 +11,14 @@ export async function startPersoenlicheDaten(
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/persoenliche-daten/name
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInput("vorname", "Donald");
   await beratungshilfeFormular.fillInput("nachname", "Duck");
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/persoenliche-daten/geburtsdatum
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInputPage("geburtsdatum", "01.01.1934");
 
   // beratungshilfe/antrag/persoenliche-daten/adresse
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInput(
     "strasseHausnummer",
     "Entenhausenstraße 123",
@@ -31,6 +28,5 @@ export async function startPersoenlicheDaten(
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/persoenliche-daten/telefonnummer
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillInputPage("telefonnummer", "123456789");
 }

--- a/tests/e2e/flowPages/beratungshilfe/formular/rechtsproblem.ts
+++ b/tests/e2e/flowPages/beratungshilfe/formular/rechtsproblem.ts
@@ -11,11 +11,9 @@ export async function startRechtsproblem(
   await beratungshilfeFormular.clickNext();
 
   // beratungshilfe/antrag/rechtsproblem/bereich
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillRadioPage("bereich", "authorities");
 
   // beratungshilfe/antrag/rechtsproblem/situation-beschreibung
-  await expectPageToBeAccessible({ page });
   await beratungshilfeFormular.fillTextarea("gegenseite", "Jobcenter");
 
   await beratungshilfeFormular.fillTextarea(

--- a/tests/e2e/flowPages/fluggastrechte/formular/startFluggastrechteFormular.ts
+++ b/tests/e2e/flowPages/fluggastrechte/formular/startFluggastrechteFormular.ts
@@ -17,43 +17,33 @@ export async function startFluggastrechteFormular(
   await formular.clickNext();
 
   // /fluggastrechte/formular/grundvoraussetzungen/prozessfaehig
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/grundvoraussetzungen/ausgleichszahlung
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/grundvoraussetzungen/zahlungsaufforderung
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/grundvoraussetzungen/daten-uebernahme
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/streitwert-kosten/gerichtskosten
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/streitwert-kosten/andere-kosten
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/streitwert-kosten/zahlung-nach-klageeinreichung
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/streitwert-kosten/prozesszinsen
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("prozesszinsen", "yes");
 
   // /fluggastrechte/formular/streitwert-kosten/versaeumnisurteil
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("versaeumnisurteil", "yes");
 
   // /fluggastrechte/formular/flugdaten/geplanter-flug
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("direktFlugnummer", "AB1234");
   await formular.fillInput("buchungsNummer", "X36Q9C");
   await formular.fillInput("direktAbflugsDatum", toGermanDateFormat(today()));
@@ -64,7 +54,6 @@ export async function startFluggastrechteFormular(
   await formular.clickNext();
 
   // /fluggastrechte/formular/flugdaten/zwischenstopp-uebersicht-1
-  await expectPageToBeAccessible({ page });
   await formular.fillAutoSuggestInputPage(
     "input-ersterZwischenstopp",
     "München",
@@ -72,37 +61,30 @@ export async function startFluggastrechteFormular(
   await formular.clickNext();
 
   // /fluggastrechte/formular/flugdaten/verspaeteter-flug-1
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage(
     "verspaeteterFlug",
     "startAirportFirstZwischenstopp",
   );
 
   // /fluggastrechte/formular/flugdaten/anschluss-flug-verpasst
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("anschlussFlugVerpasst", "yes");
 
   // /fluggastrechte/formular/flugdaten/tatsaechlicher-flug
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("tatsaechlicherFlug", "no");
 
   // /fluggastrechte/formular/flugdaten/ersatzverbindung-art
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("ersatzverbindungArt", "flug");
 
   // /fluggastrechte/formular/flugdaten/anderer-flug-ankunft
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("ersatzFlugnummer", "BCA4321");
   await formular.fillInput("ersatzFlugAnkunftsDatum", "10.01.2023");
   await formular.fillInput("ersatzFlugAnkunftsZeit", "10:10");
   await formular.clickNext();
 
   // /fluggastrechte/formular/flugdaten/zusaetzliche-angaben
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /fluggastrechte/formular/persoenliche-daten/person/daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("anrede", "Herr");
   await formular.fillDropdown("title", "");
   await formular.fillInput("nachname", "Donatello");
@@ -114,7 +96,6 @@ export async function startFluggastrechteFormular(
   await formular.clickNext();
 
   // /fluggastrechte/formular/persoenliche-daten/weitere-personen/frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("isWeiterePersonen", "no");
 
   // fluggastrechte/formular/zusammenfassung/start

--- a/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckAnnullierung.ts
+++ b/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckAnnullierung.ts
@@ -1,7 +1,6 @@
 import { type Page, expect } from "@playwright/test";
 import { CookieSettings } from "../../../pom/CookieSettings";
 import type { FluggastrechteVorabcheck } from "../../../pom/FluggastrechteVorabcheck";
-import { expectPageToBeAccessible } from "../../../util/expectPageToBeAccessible";
 
 export async function startFluggastrechteVorabcheckAnnullierung(
   page: Page,
@@ -18,30 +17,24 @@ export async function startFluggastrechteVorabcheckAnnullierung(
   await vorabcheck.fillRadioPage("bereich", "annullierung");
 
   //fluggastrechte/vorabcheck/ankuendigung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ankuendigung", "until6Days");
 
   //fluggastrechte/vorabcheck/ersatzflug
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ersatzflug", "yes");
 
   //fluggastrechte/vorabcheck/ersatzflug-starten-eine-stunde
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ersatzflugStartenEinStunde", "yes");
 
   //fluggastrechte/vorabcheck/ersatzflug-landen-zwei-stunden
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ersatzflugLandenZweiStunden", "yes");
 
   //fluggastrechte/vorabcheck/vertretbare-gruende-annullierung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("vertretbareGruendeAnnullierung", "yes");
 
   //fluggastrechte/vorabcheck/gruende-hinweis
   await vorabcheck.clickNext();
 
   // fluggastrechte/vorabcheck/verjaehrung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("verjaehrung", "yes");
 
   // fluggastrechte/vorabcheck/flughaefen

--- a/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckNichtBefoerderung.ts
+++ b/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckNichtBefoerderung.ts
@@ -1,7 +1,6 @@
 import { type Page, expect } from "@playwright/test";
 import { CookieSettings } from "../../../pom/CookieSettings";
 import type { FluggastrechteVorabcheck } from "../../../pom/FluggastrechteVorabcheck";
-import { expectPageToBeAccessible } from "../../../util/expectPageToBeAccessible";
 
 export async function startFluggastrechteVorabcheckNichtBefoerderung(
   page: Page,
@@ -14,24 +13,19 @@ export async function startFluggastrechteVorabcheckNichtBefoerderung(
   // fluggastrechte/vorabcheck/start
   await vorabcheck.clickNext();
 
-  await expectPageToBeAccessible({ page });
   // fluggastrechte/vorabcheck/bereich
   await vorabcheck.fillRadioPage("bereich", "nichtbefoerderung");
 
   // fluggastrechte/vorabcheck/ausgleich
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ausgleich", "yes");
 
   // fluggastrechte/vorabcheck/ausgleich-angenommen
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("ausgleichAngenommen", "no");
 
   // fluggastrechte/vorabcheck/checkin-nicht-befoerderung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("checkin", "yes");
 
   // fluggastrechte/vorabcheck/vertretbare-gruende
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("vertretbareGruende", "no");
 
   // fluggastrechte/vorabcheck/verjaehrung

--- a/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckVerspaetung.ts
+++ b/tests/e2e/flowPages/fluggastrechte/vorabcheck/vorabcheckVerspaetung.ts
@@ -16,30 +16,24 @@ export async function startFluggastrechteVorabcheckVerspaetung(
   await vorabcheck.clickNext();
 
   // fluggastrechte/vorabcheck/bereich
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("bereich", "verspaetet");
 
   // fluggastrechte/vorabcheck/verspaetung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("verspaetung", "yes");
 
   // fluggastrechte/vorabcheck/gruende
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("gruende", "no");
 
   // fluggastrechte/vorabcheck/verjaehrung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("verjaehrung", "yes");
 
   // fluggastrechte/vorabcheck/flughaefen
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillMultipleAutoSuggestInputPage([
     { field: "input-startAirport", value: "Berlin" },
     { field: "input-endAirport", value: "Frankfurt" },
   ]);
 
   // fluggastrechte/vorabcheck/fluggesellschaft
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillAutoSuggestInputPage(
     "input-fluggesellschaft",
     "Lufthansa",
@@ -47,31 +41,24 @@ export async function startFluggastrechteVorabcheckVerspaetung(
   await vorabcheck.clickNext();
 
   // fluggastrechte/vorabcheck/checkin
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("checkin", "yes");
 
   // fluggastrechte/vorabcheck/kostenlos
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("kostenlos", "no");
 
   // fluggastrechte/vorabcheck/rabatt
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("rabatt", "no");
 
   // fluggastrechte/vorabcheck/buchung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("buchung", "yes");
 
   // fluggastrechte/vorabcheck/abtretung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("abtretung", "no");
 
   // fluggastrechte/vorabcheck/entschaedigung
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("entschaedigung", "yes");
 
   // fluggastrechte/vorabcheck/gericht
-  await expectPageToBeAccessible({ page });
   await vorabcheck.fillRadioPage("gericht", "no");
 
   // fluggastrechte/vorabcheck/ergebnis/erfolg

--- a/tests/e2e/flowPages/geldEinklagen/formular/geldeinklagen.formular.spec.ts
+++ b/tests/e2e/flowPages/geldEinklagen/formular/geldeinklagen.formular.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
   await cookieSettings.acceptCookieBanner();
 });
 
-test("forwarded to intial step", async ({ page }) => {
+test("forwarded to initial step", async ({ page }) => {
   await expect(page).toHaveURL(
     new RegExp(
       `.+${geldEinklagenFormular.url}/${geldEinklagenFormular.initialStep}$`,
@@ -29,34 +29,27 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/dokumente
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/daten-uebernahme
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/persoenliche-daten/start
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/persoenliche-daten/anzahl
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillDropdownPage("anzahl", "1");
 
   // /geld-einklagen/formular/persoenliche-daten/name
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillDropdown("title", "");
   await geldEinklagenFormular.fillInput("nachname", "Donatello");
   await geldEinklagenFormular.fillInput("vorname", "Cowabunga");
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/persoenliche-daten/volljaehrig
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("volljaehrig", "yes");
 
   // /geld-einklagen/formular/persoenliche-daten/adresse
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInput(
     "strasseHausnummer",
     "Schildkrötenstraße 5",
@@ -66,27 +59,21 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/persoenliche-daten/telefonnummer
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInputPage("telefonnummer", "015111225588");
 
   // /geld-einklagen/formular/persoenliche-daten/gesetzliche-vertretung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("gesetzlicheVertretung", "no");
 
   // /geld-einklagen/formular/persoenliche-daten/bevollmaechtigte-person
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("bevollmaechtigtePerson", "no");
 
   // /geld-einklagen/formular/gegenseite/start
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/gegenseite/typ
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("gegenseite.typ", "privatperson");
 
   // /geld-einklagen/formular/gegenseite/privatperson-name
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillDropdown("gegenseite.privatperson.title", "");
   await geldEinklagenFormular.fillInput(
     "gegenseite.privatperson.nachname",
@@ -99,7 +86,6 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/gegenseite/privatperson-adresse
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInput(
     "gegenseite.privatperson.strasseHausnummer",
     "Schildkrötenstraße 6",
@@ -112,25 +98,21 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/gegenseite/privatperson-kontakt
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInputPage(
     "gegenseite.privatperson.telefonnummer",
     "0123456789",
   );
 
   // /geld-einklagen/formular/gegenseite/privatperson-bevollmaechtigte-person
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage(
     "gegenseite.privatperson.bevollmaechtigtePerson",
     "no",
   );
 
   // /geld-einklagen/formular/forderung/start
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/gegenseite
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInput("forderung.forderung1.betrag", "123");
   await geldEinklagenFormular.fillInput("forderung.forderung1.title", "123");
   await geldEinklagenFormular.fillInput("forderung.forderung2.betrag", "123");
@@ -138,18 +120,15 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/forderung-1-beschreibung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillTextareaPage(
     "forderung.forderung1.beschreibung",
     "I want pizza!",
   );
 
   // /geld-einklagen/formular/forderung/forderung-1-beweise
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/forderung-1-zeugen
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillDropdown(
     "forderung.forderung1.zeuge.title",
     "",
@@ -165,7 +144,6 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/person-1-adresse
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInput(
     "forderung.forderung1.person.strasseHausnummer",
     "Schildkrötenstraße 7",
@@ -181,7 +159,6 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/person-1-kontakt
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillInput(
     "forderung.forderung1.person.telefonnummer",
     "0123456789",
@@ -193,18 +170,15 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/forderung/forderung-2-beschreibung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillTextareaPage(
     "forderung.forderung2.beschreibung",
     "Gimme more pizza!",
   );
 
   // /geld-einklagen/formular/forderung/nebenforderungen
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("forderung.nebenforderungen", "no");
 
   // /geld-einklagen/formular/forderung/kosten
-  await expectPageToBeAccessible({ page });
   await expect(
     page.getByRole("paragraph").filter({
       hasText: "246",
@@ -213,19 +187,15 @@ test("geldeinklagen formular can be traversed for privatperson", async ({
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/versaeumnisurteil
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillRadioPage("versaeumnisurteil", "no");
 
   // /geld-einklagen/formular/anmerkung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.fillTextareaPage("anmerkung", "Get some pizza!");
 
   // /geld-einklagen/formular/ueberpruefung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickNext();
 
   // /geld-einklagen/formular/aenderungMitteilung
-  await expectPageToBeAccessible({ page });
   await geldEinklagenFormular.clickLabelFor("aenderungMitteilung");
   await geldEinklagenFormular.clickNext();
 

--- a/tests/e2e/flowPages/geldEinklagen/vorabcheck/geldeinklagen.vorabcheck.spec.ts
+++ b/tests/e2e/flowPages/geldEinklagen/vorabcheck/geldeinklagen.vorabcheck.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
   await cookieSettings.acceptCookieBanner();
 });
 
-test("forwarded to intial step", async ({ page }) => {
+test("forwarded to initial step", async ({ page }) => {
   await expect(page).toHaveURL(
     new RegExp(`.+${geldEinklagen.url}/${geldEinklagen.initialStep}$`),
   );
@@ -23,47 +23,33 @@ test("geldeinklagen can be traversed", async ({ page }) => {
   await expectPageToBeAccessible({ page });
   await geldEinklagen.clickNext();
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("forderung", "money");
-
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillDropdownPage("geldspanne", "above_1000");
 
   // gerichtskostenvorschuss
   await expectPageToBeAccessible({ page });
   await geldEinklagen.clickNext();
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("bereich", "travel");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("flug", "no");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("privatperson", "yes");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("gegenseite", "unternehmen");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("gegenseiteUnternehmenDeutschland", "yes");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillInputPage("gegenseiteUnternehmenPlz", "84104"); // not a partner court
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillInputPage("ortLeistungPlz", "85435"); // partner court
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("gegenseiteKontakt", "yes");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("gegenseiteFrist", "yes");
 
-  await expectPageToBeAccessible({ page });
   await geldEinklagen.fillRadioPage("digitalAusweisen", "yesWithId");
 
-  await expectPageToBeAccessible({ page });
   await expect(
     page.getByRole("heading").filter({
       hasText: "Ein Pilotgericht ist wahrscheinlich für Ihren Fall zuständig.",

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/antragstellendePerson.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/antragstellendePerson.ts
@@ -7,23 +7,18 @@ export async function startAntragstellendePerson(
   formular: ProzesskostenhilfeFormular,
 ) {
   // /prozesskostenhilfe/formular/antragstellende-person/empfaenger
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("empfaenger", "ich");
 
   // /prozesskostenhilfe/formular/antragstellende-person/unterhaltsanspruch
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("unterhaltsanspruch", "unterhalt");
 
   // /prozesskostenhilfe/formular/antragstellende-person/unterhalt
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("unterhaltssumme", "100");
 
   // /prozesskostenhilfe/formular/antragstellende-person/unterhalt-hauptsaechliches-leben
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("livesPrimarilyFromUnterhalt", "yes");
 
   // /prozesskostenhilfe/formular/antragstellende-person/unterhaltspflichtige-person
-  await expectPageToBeAccessible({ page });
   await formular.fillDropdown("unterhaltspflichtigePerson.beziehung", "mutter");
   await formular.fillInput("unterhaltspflichtigePerson.vorname", "Tom");
   await formular.fillInputPage("unterhaltspflichtigePerson.nachname", "Tom");

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenAusgaben.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenAusgaben.ts
@@ -1,12 +1,10 @@
 import type { Page } from "@playwright/test";
 import type { ProzesskostenhilfeFormular } from "tests/e2e/pom/ProzesskostenhilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenAusgaben(
   page: Page,
   formular: ProzesskostenhilfeFormular,
 ) {
   // /finanzielle-angaben/eausgaben/ausgaben-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasAusgaben", "no");
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEigentum.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEigentum.ts
@@ -15,22 +15,17 @@ export async function startFinanzielleAngabenEigentum(
   await formular.clickNext();
 
   // /finanzielle-angaben/eigentum/bankkonten-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasBankkonto", "yes");
 
   // /finanzielle-angaben/eigentum/geldanlagen-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasGeldanlage", "yes");
 
   // /finanzielle-angaben/eigentum/wertsachen-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasWertsache", "yes");
 
   // /finanzielle-angaben/eigentum/grundeigentum-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasGrundeigentum", "yes");
 
   // /finanzielle-angaben/eigentum/kraftfahrzeuge-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasKraftfahrzeug", "yes");
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEinkuenfte.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEinkuenfte.ts
@@ -8,24 +8,19 @@ export async function startFinanzielleAngabenEinkuenfte(
   formular: Formular,
 ) {
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/staatliche-leistungen
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("staatlicheLeistungen", "buergergeld");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/buergergeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("buergergeld", faker.finance.amount());
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/einkommen/erwerbstaetig
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("currentlyEmployed", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/einkommen/art
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("employmentType", "employedAndSelfEmployed");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/einkommen/netto-einkommen
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "nettoEinkuenfteAlsArbeitnehmer",
     faker.finance.amount(),
@@ -33,7 +28,6 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/einkommen/selbststaendig
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "selbststaendigMonatlichesEinkommen",
     faker.finance.amount(),
@@ -41,21 +35,17 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.fillRadioPage("selbststaendigBruttoNetto", "brutto");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/einkommen/selbststaendig-abzuege
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("selbststaendigAbzuege", faker.finance.amount());
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsweg
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("arbeitsweg", "publicTransport");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/opnv-kosten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("monatlicheOPNVKosten", faker.finance.amount());
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsplatz-entfernung
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "arbeitsplatz.strasseHausnummer",
     faker.location.streetAddress(),
@@ -69,7 +59,6 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/arbeitsausgaben-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasArbeitsausgaben", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/uebersicht
@@ -77,25 +66,20 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.clickAnchorByText("Ausgabe hinzufügen");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/arbeitsausgabe/0/daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("arbeitsausgaben#beschreibung", faker.word.sample());
   await formular.fillInput("arbeitsausgaben#betrag", faker.finance.amount());
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/uebersicht
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/rente-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("receivesPension", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/rente
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("pensionAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/leistungen/frage
-  await expectPageToBeAccessible({ page });
   await formular.fillCheckboxesPage(
     "hasWohngeld",
     "hasKrankengeld",
@@ -104,23 +88,18 @@ export async function startFinanzielleAngabenEinkuenfte(
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/leistungen/wohngeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("wohngeldAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/leistungen/krankengeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("krankengeldAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/leistungen/elterngeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("elterngeldAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/leistungen/kindergeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("kindergeldAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/weitere-einkuenfte/frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasFurtherIncome", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/weitere-einkuenfte/uebersicht
@@ -128,7 +107,6 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.clickAnchorByText("Einkunft hinzufügen");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/weitere-einkuenfte/einkunft/0/daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "weitereEinkuenfte#beschreibung",
     faker.word.sample(),
@@ -137,6 +115,5 @@ export async function startFinanzielleAngabenEinkuenfte(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/einkuenfte/weitere-einkuenfte/uebersicht
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEinkuenftePartner.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/finanzielleAngabenEinkuenftePartner.ts
@@ -8,27 +8,22 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   formular: Formular,
 ) {
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-staatliche-leistungen
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-staatlicheLeistungen", "buergergeld");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-buergergeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("partner-buergergeld", faker.finance.amount());
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-einkommen/partner-erwerbstaetig
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-currentlyEmployed", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-einkommen/partner-art
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage(
     "partner-employmentType",
     "employedAndSelfEmployed",
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-einkommen/partner-netto-einkommen
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-nettoEinkuenfteAlsArbeitnehmer",
     faker.finance.amount(),
@@ -36,7 +31,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-einkommen/partner-selbststaendig
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-selbststaendigMonatlichesEinkommen",
     faker.finance.amount(),
@@ -44,7 +38,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.fillRadioPage("partner-selbststaendigBruttoNetto", "brutto");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-einkommen/partner-selbststaendig-abzuege
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-selbststaendigAbzuege",
     faker.finance.amount(),
@@ -52,11 +45,9 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsweg
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-arbeitsweg", "publicTransport");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-opnv-kosten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-monatlicheOPNVKosten",
     faker.finance.amount(),
@@ -64,7 +55,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsplatz-entfernung
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-arbeitsplatz.strasseHausnummer",
     faker.location.streetAddress(),
@@ -78,7 +68,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgaben-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-hasArbeitsausgaben", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht
@@ -86,7 +75,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickAnchorByText("Ausgabe hinzufügen");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/0/partner-daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-arbeitsausgaben#beschreibung",
     faker.word.sample(),
@@ -98,27 +86,21 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-rente-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-receivesPension", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-rente
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("partner-pensionAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-unterhalt-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-receivesSupport", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-unterhalt
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("partner-supportAmount", faker.finance.amount());
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-leistungen/partner-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillCheckboxesPage(
     "partner-hasWohngeld",
     "partner-hasKrankengeld",
@@ -127,35 +109,30 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-leistungen/partner-wohngeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage(
     "partner-wohngeldAmount",
     faker.finance.amount(),
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-leistungen/partner-krankengeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage(
     "partner-krankengeldAmount",
     faker.finance.amount(),
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-leistungen/partner-elterngeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage(
     "partner-elterngeldAmount",
     faker.finance.amount(),
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-leistungen/partner-kindergeld
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage(
     "partner-kindergeldAmount",
     faker.finance.amount(),
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-weitere-einkuenfte/partner-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partner-hasFurtherIncome", "yes");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-weitere-einkuenfte/partner-uebersicht
@@ -163,7 +140,6 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickAnchorByText("Einkunft hinzufügen");
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-weitere-einkuenfte/partner-einkunft/0/partner-daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "partner-weitereEinkuenfte#beschreibung",
     faker.word.sample(),
@@ -175,6 +151,5 @@ export async function startFinanzielleAngabenEinkuenftePartner(
   await formular.clickNext();
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-weitere-einkuenfte/partner-uebersicht
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/gesetzlicheVertretung.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/gesetzlicheVertretung.ts
@@ -12,7 +12,6 @@ export async function startGesetzlicheVertretung(
   await formular.fillRadioPage("hasGesetzlicheVertretung", "yes");
 
   // prozesskostenhilfe/formular/gesetzliche-vertretung/daten
-  await expectPageToBeAccessible({ page });
   await formular.fillInput(
     "gesetzlicheVertretungDaten.vorname",
     faker.person.firstName(),

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/grundvoraussetzungen.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/grundvoraussetzungen.ts
@@ -1,24 +1,19 @@
 import type { Page } from "@playwright/test";
 import type { ProzesskostenhilfeFormular } from "tests/e2e/pom/ProzesskostenhilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startGrundvoraussetzungen(
   page: Page,
   formular: ProzesskostenhilfeFormular,
 ) {
   // /prozesskostenhilfe/formular/grundvoraussetzungen/nachueberpruefung-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("formularArt", "erstantrag");
 
   // /prozesskostenhilfe/formular/grundvoraussetzungen/antrag/klageersteller
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("verfahrenArt", "verfahrenAnwalt");
 
   // /prozesskostenhilfe/formular/grundvoraussetzungen/einreichung/fall
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("versandArt", "digital");
 
   // /prozesskostenhilfe/formular/grundvoraussetzungen/einreichung/hinweis-digital-einreichung
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/persoenlicheDaten.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/persoenlicheDaten.ts
@@ -8,28 +8,22 @@ export async function startPersoenlicheDaten(page: Page, formular: Formular) {
   await formular.clickNext();
 
   // prozesskostenhilfe/formular/persoenliche-daten/name
-  await expectPageToBeAccessible({ page });
-
   await formular.fillInput("vorname", "Donald");
   await formular.fillInput("nachname", "Duck");
   await formular.clickNext();
 
   // prozesskostenhilfe/formular/persoenliche-daten/geburtsdatum
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("geburtsdatum", "01.01.1934");
 
   // prozesskostenhilfe/formular/persoenliche-daten/adresse
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("strasseHausnummer", "Entenhausenstraße 123");
   await formular.fillInput("plz", "10115");
   await formular.fillInput("ort", "Entenhausen");
   await formular.clickNext();
 
   // prozesskostenhilfe/formular/persoenliche-daten/telefonnummer
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("telefonnummer", "123456789");
 
   // prozesskostenhilfe/formular/persoenliche-daten/telefonnummer
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("beruf", "developer");
 }

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/prozesskostenhilfe.formular.spec.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/prozesskostenhilfe.formular.spec.ts
@@ -73,14 +73,12 @@ test("prozesskostenhilfe formular can be traversed", async ({ page }) => {
     prozesskostenhilfeFormular,
   );
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/partner-besonders-ausgaben
-  await expectPageToBeAccessible({ page });
   await prozesskostenhilfeFormular.fillRadioPage(
     "partnerHasBesondersAusgaben",
     "yes",
   );
 
   // /prozesskostenhilfe/formular/finanzielle-angaben/partner-einkuenfte/add-partner-besonders-ausgaben
-  await expectPageToBeAccessible({ page });
   await prozesskostenhilfeFormular.fillInput(
     "partnerBesondersAusgabe.beschreibung",
     faker.word.sample(),

--- a/tests/e2e/flowPages/prozesskostenhilfe/formular/rechtsschutzversicherung.ts
+++ b/tests/e2e/flowPages/prozesskostenhilfe/formular/rechtsschutzversicherung.ts
@@ -1,14 +1,10 @@
 import type { Page } from "@playwright/test";
 import type { ProzesskostenhilfeFormular } from "tests/e2e/pom/ProzesskostenhilfeFormular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startRechtsschutzversicherung(
   page: Page,
   formular: ProzesskostenhilfeFormular,
 ) {
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasRsv", "no");
-
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasRsvThroughOrg", "no");
 }

--- a/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenAndereUnterhaltszahlungen.ts
+++ b/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenAndereUnterhaltszahlungen.ts
@@ -1,12 +1,10 @@
 import type { Page } from "@playwright/test";
 import type { Formular } from "tests/e2e/pom/Formular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenAndereUnterhaltszahlungen(
   page: Page,
   formular: Formular,
 ) {
   // /finanzielle-angaben/andere-unterhaltszahlungen/frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasWeitereUnterhaltszahlungen", "no");
 }

--- a/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenEigentumZusammenfassung.ts
+++ b/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenEigentumZusammenfassung.ts
@@ -31,11 +31,9 @@ async function addGrundeigentum(formular: Formular, page: Page) {
   await page.getByTestId("add-grundeigentum").click();
 
   // /finanzielle-angaben/eigentum-zusammenfassung/grundeigentum/0/bewohnt-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("grundeigentum#isBewohnt", "yes");
 
   // /finanzielle-angaben/eigentum-zusammenfassung/grundeigentum/0/daten
-  await expectPageToBeAccessible({ page });
   await formular.fillDropdown("grundeigentum#art", "eigentumswohnung");
   await formular.fillDropdown("grundeigentum#eigentuemer", "myself");
   await formular.fillInput("grundeigentum#flaeche", "100");
@@ -47,12 +45,10 @@ async function addGeldanlage(formular: Formular, page: Page) {
   await page.getByTestId("add-geldanlagen").click();
 
   // /finanzielle-angaben/eigentum-zusammenfassung/geldanlagen/0/art
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("geldanlagen#art", "bargeld");
 
   // /finanzielle-angaben/eigentum-zusammenfassung/geldanlagen/0/bargeld
   expect(page.url()).toContain("bargeld");
-  await expectPageToBeAccessible({ page });
   await formular.fillDropdown("geldanlagen#eigentuemer", "myself");
   await formular.fillInput("geldanlagen#wert", "100");
   await formular.clickNext();
@@ -62,15 +58,12 @@ async function addKraftfahrzeug(formular: Formular, page: Page) {
   await page.getByTestId("add-kraftfahrzeuge").click();
 
   // /finanzielle-angaben/eigentum-zusammenfassung/kraftfahrzeuge/arbeitsweg
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("kraftfahrzeuge#hasArbeitsweg", "yes");
 
   // /finanzielle-angaben/eigentum-zusammenfassung/kraftfahrzeuge/wert
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("kraftfahrzeuge#wert", "over10000");
 
   // /finanzielle-angaben/eigentum-zusammenfassung/kraftfahrzeuge/fahrzeuge
-  await expectPageToBeAccessible({ page });
   await formular.fillDropdown("kraftfahrzeuge#eigentuemer", "myself");
 
   await formular.fillInput("kraftfahrzeuge#art", "Trabant");
@@ -88,7 +81,6 @@ async function addBankkonto(page: Page, formular: Formular) {
   await page.getByTestId("add-bankkonten").click();
 
   // /finanzielle-angaben/eigentum/bankkonten
-  await expectPageToBeAccessible({ page });
   await formular.fillDropdown("bankkonten#kontoEigentuemer", "myself");
 
   await formular.fillInput(

--- a/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenKinder.ts
+++ b/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenKinder.ts
@@ -7,7 +7,6 @@ export async function startFinanzielleAngabenKinder(
   formular: Formular,
 ) {
   // /finanzielle-angaben/kinder/kinder-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("hasKinder", "yes");
 
   // /finanzielle-angaben/kinder/uebersicht
@@ -15,25 +14,20 @@ export async function startFinanzielleAngabenKinder(
   await formular.clickAnchorByText("Kind hinzufügen");
 
   // /finanzielle-angaben/kinder/kinder/0/name
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("kinder#vorname", "Clara");
   await formular.fillInput("kinder#nachname", "Musterian");
   await formular.fillInput("kinder#geburtsdatum", "12.12.2020");
   await formular.clickNext();
 
   // /finanzielle-angaben/kinder/kinder/0/wohnort
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("kinder#wohnortBeiAntragsteller", "yes");
 
   // /finanzielle-angaben/kinder/kinder/0/kind-eigene-einnahmen-frage
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("kinder#eigeneEinnahmen", "yes");
 
   // /finanzielle-angaben/kinder/kinder/0/kind-eigene-einnahmen
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("kinder#einnahmen", "5");
 
   // /finanzielle-angaben/kinder/uebersicht
-  await expectPageToBeAccessible({ page });
   await formular.clickNext();
 }

--- a/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenPartner.ts
+++ b/tests/e2e/flowPages/shared/finanzielleAngaben/finanzielleAngabenPartner.ts
@@ -1,29 +1,23 @@
 import type { Page } from "@playwright/test";
 import type { Formular } from "tests/e2e/pom/Formular";
-import { expectPageToBeAccessible } from "tests/e2e/util/expectPageToBeAccessible";
 
 export async function startFinanzielleAngabenPartner(
   page: Page,
   formular: Formular,
 ) {
   // /finanzielle-angaben/partner/partnerschaft
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("partnerschaft", "yes");
 
   // /finanzielle-angaben/partner/zusammenleben
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("zusammenleben", "no");
 
   // /finanzielle-angaben/partner/unterhalt
-  await expectPageToBeAccessible({ page });
   await formular.fillRadioPage("unterhalt", "yes");
 
   // /finanzielle-angaben/partner/unterhalts-summe
-  await expectPageToBeAccessible({ page });
   await formular.fillInputPage("unterhaltsSumme", "100");
 
   // /finanzielle-angaben/partner/partner-name
-  await expectPageToBeAccessible({ page });
   await formular.fillInput("partnerVorname", "Dagobert");
   await formular.fillInput("partnerNachname", "Duck");
   await formular.clickNext();


### PR DESCRIPTION
### Changes

- Remove accessibility tests of all the Formular pages
- Keep the accessibility tests on start, abgabe and übersicht pages
- Remove accessibility tests of Vorabcheck Fluggasterechte and Geldeinklage