### PR TITLE
refactor(move unit tests to pre-push git hook)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,5 +7,8 @@ pre-commit:
       run: npm run lint
     typecheck:
       run: npm run typecheck
+
+pre-push:
+  commands:
     "unit tests":
       run: npm test


### PR DESCRIPTION
This PR moves the unit tests command to the `pre-push` stage (instead of `pre-commit`), as our unit tests are growing ever larger and it's annoying to run them for every commit.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208674492323937