### PR TITLE
fix(text-link): use border-bottom due issue space safari

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -83,7 +83,7 @@ svg {
 /* Only apply hover effect on devices that support it, see https://stackoverflow.com/a/28058919 */
 @media (hover: hover) {
   .text-link:hover {
-    @apply decoration-[3px];
+    border-bottom: 3px solid var(--background-color-blue-800, #004b76);
   }
 }
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -83,6 +83,7 @@ svg {
 /* Only apply hover effect on devices that support it, see https://stackoverflow.com/a/28058919 */
 @media (hover: hover) {
   .text-link:hover {
+    /* use border-bottom instead of decoration due issues of safari space*/
     border-bottom: 3px solid var(--background-color-blue-800, #004b76);
   }
 }


### PR DESCRIPTION
### Changes

- Use border-bottom instead of text-decoration-thickness to not add space to the box and avoid issues in Safari

Ticket: https://app.asana.com/0/1207022303033556/1208745489995869

