### PR TITLE
Remove restore-keys

### DIFF
--- a/.github/actions/cached-checkout-install/action.yml
+++ b/.github/actions/cached-checkout-install/action.yml
@@ -21,6 +21,5 @@ runs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
     - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
       name: Perform a clean install of node dependencies
-      continue-on-error: true
       run: npm ci
       shell: bash

--- a/.github/actions/cached-checkout-install/action.yml
+++ b/.github/actions/cached-checkout-install/action.yml
@@ -19,11 +19,6 @@ runs:
       with:
         path: ./node_modules
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.NODE_VERSION }}-
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
       name: Perform a clean install of node dependencies
       continue-on-error: true


### PR DESCRIPTION
### Changes
Remove the `restore-keys` option, so we only get the cache from the key. I have noticed sometimes we are getting a node-module cache in dependent bot PRs, even we have a new dependency update.

<img width="726" alt="image" src="https://github.com/user-attachments/assets/4cdf72b2-0210-45b8-bbce-4593e53991cc">
