### PR TITLE
chore(e2e): reduce timeouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,13 +22,13 @@ const baseURL = useDefaultBaseUrl
 export default defineConfig({
   testDir: "./tests/e2e",
   /* Maximum time one test can run for. */
-  timeout: 5 * 60 * 1000,
+  timeout: 2 * 60 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5 * 1000,
+    timeout: 2 * 1000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
Lower timeouts lead to faster failure, saving dev and CI time (thanks to running e2e tests against prod server)