### PR TITLE
fix(pdf-service): fix bug with German umlauts not rendered correctly in pdf

### DIFF
--- a/app/domains/prozesskostenhilfe/services/pdf/pdfForm/G_eigentum.ts
+++ b/app/domains/prozesskostenhilfe/services/pdf/pdfForm/G_eigentum.ts
@@ -166,7 +166,7 @@ export const fillBargeldOderWertgegenstaende: PkhPdfFillFunction = ({
         text: `${bargeld.wert} €`,
       },
       {
-        title: "Eigentümer:in",
+        title: "Eigentümer:in",
         text: eigentuemer,
       },
     );
@@ -187,7 +187,7 @@ export const fillBargeldOderWertgegenstaende: PkhPdfFillFunction = ({
         text: `${wertsache.wert} €`,
       },
       {
-        title: "Eigentümer:in",
+        title: "Eigentümer:in",
         text: eigentuemerMapping[wertsache.eigentuemer],
       },
     );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -161,7 +161,7 @@ export default tseslint.config(
           selector:
             "Literal[value=/(a\u0308)|(o\u0308)|(u\u0308)|(A\u0308)|(O\u0308)|(U\u0308)/]",
           message:
-            "German umlauts must be written as NFC (normalized form canonical composition) and not NFD (normalized form canonical decomposition). E.g. use 'ä' instead of tha character 'a' followd by the combining diacritical marks ' ̈'.",
+            "German umlauts must be written as NFC (normalized form canonical composition) and not NFD (normalized form canonical decomposition). E.g. use 'ä' instead of the character 'a' followed by the combining diacritical marks ' ̈'.",
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -154,6 +154,16 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/prefer-nullish-coalescing": "off",
+
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "Literal[value=/(a\u0308)|(o\u0308)|(u\u0308)|(A\u0308)|(O\u0308)|(U\u0308)/]",
+          message:
+            "German umlauts must be written as NFC (normalized form canonical composition) and not NFD (normalized form canonical decomposition). E.g. use 'ä' instead of tha character 'a' followd by the combining diacritical marks ' ̈'.",
+        },
+      ],
     },
   },
   // Vitest


### PR DESCRIPTION
I could only reproduce this bug with the arc browser. The root cause were two titles in `bargeld` and `wertsachen` where the 'ü' of `Eigentümer:in` was written as a NFD (normalized form canonical decomposition) which means the 'u' was typed first, followed by the combining diacritical marks. `pdfkit` does not seem to properly support encoding these characters in few cases (arc browser).
Proposal: Added a linter rule that detects NFDs.

https://app.asana.com/0/1203259475859667/1208834671333919