### PR TITLE
chore(lefthook): move lint to pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,12 +3,13 @@ pre-commit:
   commands:
     format:
       run: node_modules/.bin/prettier --write '{staged_files}' && git add '{staged_files}'
-    lint:
-      run: npm run lint
     typecheck:
       run: npm run typecheck
 
 pre-push:
+  parallel: true
   commands:
     "unit tests":
       run: npm test
+    lint:
+      run: npm run lint


### PR DESCRIPTION
Linting now takes quite a bit of time due to requiring a typescript build

suggestion:
 - move linting hook from pre-commit to pre-push
 - run in parallel to unit tests

reason: we probably all have linting set up in our IDEs, the hook should just be a failsafe