### PR TITLE
fix(BMJ Logo Accessibility)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -33,11 +33,7 @@ export default function Footer({
         <div className="flex flex-col flex-col-reverse sm:flex-row gap-y-8 gap-x-16">
           {image?.url && (
             <div>
-              <Image
-                url={image.url}
-                width={120}
-                alternativeText={image.alternativeText}
-              />
+              <Image {...image} width={120} />
             </div>
           )}
           <div className="ds-stack-8">

--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -1,5 +1,8 @@
+import SVG from "react-inlinesvg";
+
 export type ImageProps = Readonly<{
   url?: string;
+  ext?: string;
   width?: number;
   height?: number;
   alternativeText?: string;
@@ -8,7 +11,18 @@ export type ImageProps = Readonly<{
 
 function Image({ url, width, height, alternativeText, ...props }: ImageProps) {
   if (!url) return null;
-  return (
+  // Need to inline SVG components for accessibility
+  const isSvg = props.ext === ".svg";
+  return isSvg ? (
+    <SVG
+      {...props}
+      src={url}
+      width={width}
+      title={alternativeText}
+      role="img"
+      height={"auto"}
+    />
+  ) : (
     <img
       {...props}
       src={url}

--- a/app/services/cms/models/StrapiImage.ts
+++ b/app/services/cms/models/StrapiImage.ts
@@ -41,6 +41,12 @@ export const getImageProps = (
   cmsData: StrapiImage | null,
 ): ImageProps | undefined => {
   if (!cmsData) return undefined;
-  const { url, width, height, alternativeText } = cmsData;
-  return { url, width, height, alternativeText: alternativeText ?? undefined };
+  const { url, width, height, alternativeText, ext } = cmsData;
+  return {
+    url,
+    width,
+    ext,
+    height,
+    alternativeText: alternativeText ?? undefined,
+  };
 };

--- a/app/services/cms/models/__test__/StrapiImage.test.ts
+++ b/app/services/cms/models/__test__/StrapiImage.test.ts
@@ -21,6 +21,7 @@ describe("getImageProps", () => {
 
     expect(result).toEqual({
       url: "url",
+      ext: ".ext",
       width: 1,
       height: 2,
       alternativeText: "alternativeText",

--- a/app/services/security/cspHeader.server.tsx
+++ b/app/services/security/cspHeader.server.tsx
@@ -24,6 +24,7 @@ export const cspHeader = (args: {
     "connect-src": [
       "'self'",
       "eu.i.posthog.com",
+      "https://a2j-rechtsantragstelle-infra-public-assets-bucket.obs.eu-de.otc.t-systems.com",
       ...(args.additionalConnectSrc ?? []),
     ],
     "img-src": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "react-collapsed": "^4.1.2",
         "react-dom": "^18.3.1",
         "react-imask": "^7.6.1",
+        "react-inlinesvg": "^4.1.5",
         "react-select": "^5.9.0",
         "remix-validated-form": "^5.1.5",
         "samlify": "^2.8.11",
@@ -15647,6 +15648,15 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-from-dom": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.7.3.tgz",
+      "integrity": "sha512-9IK6R7+eD1wOAMC2ZCrENev0eK1625cb7vX+cnnOR9LBRNbjKiaJk4ij2zQbcefEXTWjXFhA7CTO1cd8wMONnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
@@ -15661,6 +15671,18 @@
       },
       "peerDependencies": {
         "react": ">=0.14.0"
+      }
+    },
+    "node_modules/react-inlinesvg": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-4.1.5.tgz",
+      "integrity": "sha512-DcCnmHhpKAUNp6iLPEEB2HJP3simDlyiy8JPZ1DwGCynrQQGQD04GJTFtai8JK8vRhCmoiBV6hSgj31D42Z3Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-from-dom": "^0.7.3"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-collapsed": "^4.1.2",
     "react-dom": "^18.3.1",
     "react-imask": "^7.6.1",
+    "react-inlinesvg": "^4.1.5",
     "react-select": "^5.9.0",
     "remix-validated-form": "^5.1.5",
     "samlify": "^2.8.11",


### PR DESCRIPTION
This PR ensures that SVGs are displayed as inline components for accessibility, specifically with high-contrast display modes.

![Bildschirmfoto 2024-12-23 um 15 00 29](https://github.com/user-attachments/assets/52414135-83e4-43ad-9f5d-3b3956aea865)

