### PR TITLE
test(pkh flow): add forward-only flow tests

### DIFF
--- a/app/domains/__test__/flows.test.ts
+++ b/app/domains/__test__/flows.test.ts
@@ -32,7 +32,10 @@ import { testCasesFluggastrechteVerspaetetAbbruch } from "~/domains/fluggastrech
 import { testCasesGeldEinklagen } from "~/domains/geldEinklagen/vorabcheck/__test__/testcases";
 import { testCasesProzesskostenhilfeFormular } from "~/domains/prozesskostenhilfe/formular/__test__/testcases";
 import { testCasesProzesskostenhilfePersoenlicheDaten } from "~/domains/prozesskostenhilfe/formular/persoenlicheDaten/__test__/testcases";
-import { testCasesProzesskostenhilfeRsv } from "~/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases";
+import {
+  testCasesProzesskostenhilfeForwardOnly,
+  testCasesProzesskostenhilfeRsv,
+} from "~/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases";
 import type { FlowStateMachine } from "~/services/flow/server/buildFlowController";
 import { nextStepId } from "~/services/flow/server/buildFlowController";
 import { stateValueToStepIds } from "~/services/flow/stepIdConverter";
@@ -158,6 +161,31 @@ describe.sequential("state machine form flows", () => {
     },
   );
 
+  // Array pages cannot be tested above since they aren't reachable using the `BACK` transition
+  // However, we can still verify that their `SUBMIT` transition is correct
+  const forwardOnlyTests = {
+    testCasesProzesskostenhilfeForwardOnly,
+  };
+
+  describe.concurrent.each(Object.entries(forwardOnlyTests))(
+    "%s",
+    (_, { machine, cases }) => {
+      test.each([...cases])("[%#]", (context, steps) => {
+        const visitedSteps = getEnabledSteps({
+          machine,
+          context,
+          transitionType: "SUBMIT",
+          steps,
+        });
+
+        allVisitedSteps[machine.id].stepIds =
+          allVisitedSteps[machine.id].stepIds.concat(visitedSteps);
+
+        expect(visitedSteps).toEqual(steps);
+      });
+    },
+  );
+
   test("all steps are visited", () => {
     const missingStepsEntries = Object.entries(allVisitedSteps)
       .map(([machineId, { machine, stepIds }]) => {
@@ -179,6 +207,6 @@ describe.sequential("state machine form flows", () => {
       `Total of ${totalMissingStepCount} untested stepIds: `,
       Object.fromEntries(missingStepsEntries),
     );
-    expect(totalMissingStepCount).toBeLessThanOrEqual(25);
+    expect(totalMissingStepCount).toBeLessThanOrEqual(18);
   });
 });

--- a/app/domains/__test__/flows.test.ts
+++ b/app/domains/__test__/flows.test.ts
@@ -30,12 +30,11 @@ import { testCasesFluggastrechteNichtBefoerderungAbbruch } from "~/domains/flugg
 import { testcasesFluggastrechtOtherErfolgs } from "~/domains/fluggastrechte/vorabcheck/__test__/testcasesOtherErfolgs";
 import { testCasesFluggastrechteVerspaetetAbbruch } from "~/domains/fluggastrechte/vorabcheck/__test__/testcasesVerspaetetAbbruch";
 import { testCasesGeldEinklagen } from "~/domains/geldEinklagen/vorabcheck/__test__/testcases";
-import { testCasesProzesskostenhilfeFormular } from "~/domains/prozesskostenhilfe/formular/__test__/testcases";
-import { testCasesProzesskostenhilfePersoenlicheDaten } from "~/domains/prozesskostenhilfe/formular/persoenlicheDaten/__test__/testcases";
 import {
-  testCasesProzesskostenhilfeForwardOnly,
-  testCasesProzesskostenhilfeRsv,
-} from "~/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases";
+  testCasesProzesskostenhilfeFormular,
+  testCasesProzesskostenhilfeSubmitOnly,
+} from "~/domains/prozesskostenhilfe/formular/__test__/testcases";
+import { testCasesProzesskostenhilfePersoenlicheDaten } from "~/domains/prozesskostenhilfe/formular/persoenlicheDaten/__test__/testcases";
 import type { FlowStateMachine } from "~/services/flow/server/buildFlowController";
 import { nextStepId } from "~/services/flow/server/buildFlowController";
 import { stateValueToStepIds } from "~/services/flow/stepIdConverter";
@@ -123,7 +122,6 @@ describe.sequential("state machine form flows", () => {
     testCasesFluggastrechteFormularGrundvoraussetzungen,
     testCasesFluggastrechteFormularStreitwertKosten,
     testCasesProzesskostenhilfePersoenlicheDaten,
-    testCasesProzesskostenhilfeRsv,
     testCasesFluggastrechteFormularFlugdatenVerspaetet,
     testCasesFluggastrechteFormularFlugdatenAnnullierung,
     testCasesFluggastrechteErfolg,
@@ -161,11 +159,9 @@ describe.sequential("state machine form flows", () => {
     },
   );
 
-  // Array pages cannot be tested above since they aren't reachable using the `BACK` transition
+  // Some pages cannot be tested above since they aren't reachable using a `BACK` transition
   // However, we can still verify that their `SUBMIT` transition is correct
-  const forwardOnlyTests = {
-    testCasesProzesskostenhilfeForwardOnly,
-  };
+  const forwardOnlyTests = { testCasesProzesskostenhilfeSubmitOnly };
 
   describe.concurrent.each(Object.entries(forwardOnlyTests))(
     "%s",

--- a/app/domains/prozesskostenhilfe/formular/__test__/testcases.ts
+++ b/app/domains/prozesskostenhilfe/formular/__test__/testcases.ts
@@ -14,6 +14,7 @@ import { testCasesPKHFormularFinanzielleAngabenEinkuenfte } from "../finanzielle
 import { testCasesPKHFormularFinanzielleAngabenKinder } from "../finanzielleAngaben/__test__/testcasesKinder";
 import { testCasesPKHFormularFinanzielleAngabenPartner } from "../finanzielleAngaben/__test__/testcasesPartner";
 import { testCasesPKHFormularFinanzielleAngabenWohnung } from "../finanzielleAngaben/__test__/testcasesWohnung";
+import { testCasesProzesskostenhilfeRsv } from "../rechtsschutzversicherung/__test__/testcases";
 
 export const machine: FlowStateMachine = createMachine(
   { ...prozesskostenhilfeFormular.config, context: {} },
@@ -60,6 +61,7 @@ const cases = [
   ...testCasesPKHFormularFinanzielleAngabenAndereUnterhaltszahlungen,
   ...testCasesPKHFormularFinanzielleAngabenEigentum,
   ...testCasesPKHFormularFinanzielleAngabenAusgaben,
+  ...testCasesProzesskostenhilfeRsv,
   [
     happyPathData,
     [
@@ -75,6 +77,68 @@ const cases = [
     ],
   ],
 ] satisfies TestCases<ProzesskostenhilfeFormularContext>;
+
+export const testCasesProzesskostenhilfeSubmitOnly = {
+  machine,
+  cases: [
+    [
+      {},
+      [
+        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/arbeitsausgabe/daten",
+        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/einkunft/daten",
+        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-einkunft/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/andere-unterhaltszahlungen/person/daten",
+        "/finanzielle-angaben/andere-unterhaltszahlungen/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/eigentum-zusammenfassung/bankkonten/daten",
+        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/eigentum-zusammenfassung/wertgegenstaende/daten",
+        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
+      ],
+    ],
+  ] satisfies TestCases<ProzesskostenhilfeFormularContext>,
+};
 
 export const testCasesProzesskostenhilfeFormular = {
   machine,

--- a/app/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases.ts
+++ b/app/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases.ts
@@ -87,3 +87,65 @@ export const testCasesProzesskostenhilfeRsv = {
     steps.map((stepId) => prefix + stepId),
   ]) satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>,
 };
+
+export const testCasesProzesskostenhilfeForwardOnly = {
+  machine,
+  cases: [
+    [
+      {},
+      [
+        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/arbeitsausgabe/daten",
+        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/einkunft/daten",
+        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-einkunft/partner-daten",
+        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/andere-unterhaltszahlungen/person/daten",
+        "/finanzielle-angaben/andere-unterhaltszahlungen/uebersicht",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/eigentum-zusammenfassung/bankkonten/daten",
+        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
+      ],
+    ],
+    [
+      {},
+      [
+        "/finanzielle-angaben/eigentum-zusammenfassung/wertgegenstaende/daten",
+        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
+      ],
+    ],
+  ] satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>,
+};

--- a/app/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases.ts
+++ b/app/domains/prozesskostenhilfe/formular/rechtsschutzversicherung/__test__/testcases.ts
@@ -1,151 +1,85 @@
 import type { TestCases } from "~/domains/__test__/TestCases";
-import { machine } from "~/domains/prozesskostenhilfe/formular/__test__/testcases";
 import type { ProzesskostenhilfeRechtsschutzversicherungContext } from "../context";
 const prefix = "/rechtsschutzversicherung";
 
-const cases = [
+export const testCasesProzesskostenhilfeRsv = (
   [
-    {
-      hasRsv: "no",
-    },
-    ["/rsv-frage", "/org-frage"],
-  ],
-  [
-    {
-      hasRsv: "yes",
-      hasRsvCoverage: "yes",
-    },
-    ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-ja"],
-  ],
-  [
-    {
-      hasRsv: "yes",
-      hasRsvCoverage: "unknown",
-    },
-    ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-unbekannt"],
-  ],
-  [
-    {
-      hasRsv: "yes",
-      hasRsvCoverage: "no",
-    },
-    ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-nein", "/org-frage"],
-  ],
-  [
-    {
-      hasRsv: "yes",
-      hasRsvCoverage: "partly",
-    },
-    ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-teilweise", "/org-frage"],
-  ],
-  [
-    {
-      hasRsv: "no",
-      hasRsvThroughOrg: "yes",
-      hasOrgCoverage: "no",
-    },
-    ["/rsv-frage", "/org-frage", "/org-deckung"],
-  ],
-  [
-    {
-      hasRsv: "no",
-      hasRsvThroughOrg: "yes",
-      hasOrgCoverage: "unknown",
-    },
-    ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-unbekannt"],
-  ],
-  [
-    {
-      hasRsv: "no",
-      hasRsvThroughOrg: "yes",
-      hasOrgCoverage: "yes",
-    },
-    ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-ja"],
-  ],
-  [
-    {
-      hasRsv: "no",
-      hasRsvThroughOrg: "yes",
-      hasOrgCoverage: "no",
-    },
-    ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-nein"],
-  ],
-  [
-    {
-      hasRsv: "no",
-      hasRsvThroughOrg: "yes",
-      hasOrgCoverage: "partly",
-    },
-    ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-teilweise"],
-  ],
-] satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>;
-
-export const testCasesProzesskostenhilfeRsv = {
-  machine,
-  cases: cases.map(([data, steps]) => [
-    data,
-    steps.map((stepId) => prefix + stepId),
-  ]) satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>,
-};
-
-export const testCasesProzesskostenhilfeForwardOnly = {
-  machine,
-  cases: [
     [
-      {},
-      [
-        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/arbeitsausgabe/daten",
-        "/finanzielle-angaben/einkuenfte/abzuege/arbeitsausgaben/uebersicht",
-      ],
+      {
+        hasRsv: "no",
+      },
+      ["/rsv-frage", "/org-frage"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/einkunft/daten",
-        "/finanzielle-angaben/einkuenfte/weitere-einkuenfte/uebersicht",
-      ],
+      {
+        hasRsv: "yes",
+        hasRsvCoverage: "yes",
+      },
+      ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-ja"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
-      ],
+      {
+        hasRsv: "yes",
+        hasRsvCoverage: "unknown",
+      },
+      ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-unbekannt"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-arbeitsausgabe/partner-daten",
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-abzuege/partner-arbeitsausgaben/partner-uebersicht",
-      ],
+      {
+        hasRsv: "yes",
+        hasRsvCoverage: "no",
+      },
+      ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-nein", "/org-frage"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-einkunft/partner-daten",
-        "/finanzielle-angaben/partner/partner-einkuenfte/partner-weitere-einkuenfte/partner-uebersicht",
-      ],
+      {
+        hasRsv: "yes",
+        hasRsvCoverage: "partly",
+      },
+      ["/rsv-frage", "/rsv-deckung", "/rsv-deckung-teilweise", "/org-frage"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/andere-unterhaltszahlungen/person/daten",
-        "/finanzielle-angaben/andere-unterhaltszahlungen/uebersicht",
-      ],
+      {
+        hasRsv: "no",
+        hasRsvThroughOrg: "yes",
+        hasOrgCoverage: "no",
+      },
+      ["/rsv-frage", "/org-frage", "/org-deckung"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/eigentum-zusammenfassung/bankkonten/daten",
-        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
-      ],
+      {
+        hasRsv: "no",
+        hasRsvThroughOrg: "yes",
+        hasOrgCoverage: "unknown",
+      },
+      ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-unbekannt"],
     ],
     [
-      {},
-      [
-        "/finanzielle-angaben/eigentum-zusammenfassung/wertgegenstaende/daten",
-        "/finanzielle-angaben/eigentum-zusammenfassung/zusammenfassung",
-      ],
+      {
+        hasRsv: "no",
+        hasRsvThroughOrg: "yes",
+        hasOrgCoverage: "yes",
+      },
+      ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-ja"],
     ],
-  ] satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>,
-};
+    [
+      {
+        hasRsv: "no",
+        hasRsvThroughOrg: "yes",
+        hasOrgCoverage: "no",
+      },
+      ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-nein"],
+    ],
+    [
+      {
+        hasRsv: "no",
+        hasRsvThroughOrg: "yes",
+        hasOrgCoverage: "partly",
+      },
+      ["/rsv-frage", "/org-frage", "/org-deckung", "/org-deckung-teilweise"],
+    ],
+  ] as const
+).map(([data, steps]) => [
+  data,
+  steps.map((stepId) => prefix + stepId),
+]) satisfies TestCases<ProzesskostenhilfeRechtsschutzversicherungContext>;


### PR DESCRIPTION
We have a few flow steps (mostly warning or array pages) that are not reachable using the `BACK` event. therefore, they can't really be tested inside a flow-test. I propose a forward-only test to at least cover the existing transition