### PR TITLE
fix: ignore end of line during parsing

### DIFF
--- a/data/airlines/data.json
+++ b/data/airlines/data.json
@@ -861,8 +861,8 @@
   },
   {
     "name": "Malta Air Limited",
-    "iata": "",
-    "isInEU": false,
+    "iata": "MW",
+    "isInEU": true,
     "arbitrationBoard": "RV"
   },
   {

--- a/scripts/airlines.ts
+++ b/scripts/airlines.ts
@@ -43,7 +43,7 @@ function saveAirlinesInFile(airlines: Airline[]): void {
 function generateAirlinesData(filePath: string) {
   const content = fs.readFileSync(filePath, { encoding: "utf-8" });
 
-  const rows = content.split("\n");
+  const rows = content.split("\n").filter((row) => row.trim() !== "");
   const airlines: Airline[] = [];
   rows.forEach((row) => {
     const airline = processAirlineRow(row);


### PR DESCRIPTION
## Problem
Users can click without choosing an airline, and validations do not fail. When they click forward, and then return to the airline page, it is set to Malta Air.

## Solution
- Malta is missing the IATA code
- Fix EoL error 

## Next Steps
We need to throw an error when the data being parsed is invalid.