### PR TITLE
feat: allow to pass alternative schema

### DIFF
--- a/app/domains/fluggastrechte/formular/flugdaten/context.ts
+++ b/app/domains/fluggastrechte/formular/flugdaten/context.ts
@@ -63,12 +63,22 @@ export const fluggastrechteFlugdaten = {
   ersatzFlugAnkunftsZeit: timeSchema,
   zusaetzlicheAngaben: stringOptionalSchema,
   annullierungErsatzverbindungFlugnummer: optionalOrSchema(flightNumberSchema),
-  annullierungErsatzverbindungAbflugsDatum:
-    optionalOrSchema(fourYearsAgoSchema),
-  annullierungErsatzverbindungAbflugsZeit: optionalOrSchema(timeSchema),
-  annullierungErsatzverbindungAnkunftsDatum:
-    optionalOrSchema(fourYearsAgoSchema),
-  annullierungErsatzverbindungAnkunftsZeit: optionalOrSchema(timeSchema),
+  annullierungErsatzverbindungAbflugsDatum: optionalOrSchema(
+    fourYearsAgoSchema,
+    z.literal(""), // we need to set default value (empty string), so that the client-side validation works
+  ),
+  annullierungErsatzverbindungAbflugsZeit: optionalOrSchema(
+    timeSchema,
+    z.literal(""),
+  ),
+  annullierungErsatzverbindungAnkunftsDatum: optionalOrSchema(
+    fourYearsAgoSchema,
+    z.literal(""),
+  ),
+  annullierungErsatzverbindungAnkunftsZeit: optionalOrSchema(
+    timeSchema,
+    z.literal(""),
+  ),
 };
 
 const _contextObject = z.object(fluggastrechteFlugdaten).partial();

--- a/app/services/validation/__test__/optionalOrSchema.test.ts
+++ b/app/services/validation/__test__/optionalOrSchema.test.ts
@@ -22,4 +22,12 @@ describe("optionalOrSchema", () => {
   it("disallows wrong schema as input", () => {
     expect(() => schema.parse("12")).toThrow();
   });
+
+  it("fallbacks to the optional schema when it is defined", () => {
+    const schemaWithOptional = optionalOrSchema(
+      z.string().length(3),
+      z.string().length(1),
+    );
+    expect(schemaWithOptional.parse("1")).toEqual("1");
+  });
 });

--- a/app/services/validation/__test__/optionalOrSchema.test.ts
+++ b/app/services/validation/__test__/optionalOrSchema.test.ts
@@ -30,4 +30,13 @@ describe("optionalOrSchema", () => {
     );
     expect(schemaWithOptional.parse("1")).toEqual("1");
   });
+
+  it("disallows input that does not match the optional schema", () => {
+    const schemaWithOptional = optionalOrSchema(
+      z.string().length(3),
+      z.string().length(1),
+    );
+    expect(() => schemaWithOptional.parse("12")).toThrow();
+    expect(() => schemaWithOptional.parse("1234")).toThrow();
+  });
 });

--- a/app/services/validation/optionalOrSchema.ts
+++ b/app/services/validation/optionalOrSchema.ts
@@ -2,6 +2,7 @@ import { z, type ZodEffects, type ZodString, type ZodTypeAny } from "zod";
 
 export const optionalOrSchema = (
   schema: ZodEffects<ZodTypeAny> | ZodString,
+  optionalSchema: ZodTypeAny = z.string().trim().max(0),
 ) => {
-  return schema.or(z.string().trim().max(0)); //either optional or proper schema,
+  return schema.optional().or(optionalSchema); //either optional or proper schema,
 };


### PR DESCRIPTION
For the FGR case, we need to set the value of the `annullierung` schema to an empty string, as it is optional.