### PR TITLE
Enhance (flowIdFromPathname): Handle nested flowIds 

### DIFF
--- a/app/domains/__test__/flowIds.test.ts
+++ b/app/domains/__test__/flowIds.test.ts
@@ -29,6 +29,13 @@ describe("flowIdFromPathname", () => {
     );
   });
 
+  it("fail to extract the nested path segments if flowId doesn't", () => {
+    expect(flowIdFromPathname("/schulden/kontopfaendung/wegweiser")).toEqual(
+      // should be updated after adding /schulden/kontopfaendung/wegweiser to context and flowIds
+      undefined,
+    );
+  });
+
   it("returns undefined if no valid flow Id", () => {
     expect(flowIdFromPathname("")).toBeUndefined();
     expect(flowIdFromPathname("asd")).toBeUndefined();

--- a/app/domains/flowIds.ts
+++ b/app/domains/flowIds.ts
@@ -10,11 +10,14 @@ export const flowIds = [
 
 export type FlowId = (typeof flowIds)[number];
 
-const isFlowId = (s: string): s is FlowId => flowIds.includes(s as FlowId);
-
+/**
+ * Match pathname with flowId or pathname that start with flowId/
+ * @param pathname
+ */
 export function flowIdFromPathname(pathname: string) {
-  const flowIdMaybe = pathname.split("/").slice(0, 3).join("/");
-  return isFlowId(flowIdMaybe) ? flowIdMaybe : undefined;
+  return flowIds.find((flowId) => {
+    return pathname === flowId || pathname.startsWith(flowId + "/");
+  });
 }
 
 export function parsePathname(pathname: string) {


### PR DESCRIPTION
To build Kontopfändung vorabcheck.flow we need to handle the case of nested flowIds ex: `/schulden/kontopfaendung/wegweiser` 

