### PR TITLE
Implement mobile-only SideNav

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -32,7 +32,7 @@ export default function Footer({
     translations,
   );
   return (
-    <Container paddingTop="48" paddingBottom="0">
+    <Container paddingTop="48" paddingBottom="56">
       <div
         className="flex flex-wrap items-start justify-between gap-y-32 mb-32"
         data-testid="footer"

--- a/app/components/navigation/FlowNavigation.tsx
+++ b/app/components/navigation/FlowNavigation.tsx
@@ -1,14 +1,21 @@
 import type { FlowNavigationProps } from "~/components/navigation/NavigationList";
 import { NavigationList } from "~/components/navigation/NavigationList";
+import SideNavMobile from "~/components/navigation/SideNavMobile";
 
 export default function FlowNavigation(props: FlowNavigationProps) {
   return (
-    <nav
-      role="navigation"
-      aria-label={props.a11yLabels?.menuLabel}
-      className="bg-white border-[1px] border-blue-400"
-    >
-      <NavigationList {...props} />
+    <nav role="navigation" aria-label={props.a11yLabels?.menuLabel}>
+      <SideNavMobile
+        className={"fixed bottom-0 w-full md:hidden"}
+        label={"Bereich"}
+        currentPageTitle={"Anwaltliche Vertretung"}
+      />
+      <NavigationList
+        {...props}
+        className={
+          "hidden md:block ml-32 bg-white border-[1px] border-blue-400"
+        }
+      />
     </nav>
   );
 }

--- a/app/components/navigation/FlowNavigation.tsx
+++ b/app/components/navigation/FlowNavigation.tsx
@@ -6,9 +6,10 @@ export default function FlowNavigation(props: FlowNavigationProps) {
   return (
     <nav role="navigation" aria-label={props.a11yLabels?.menuLabel}>
       <SideNavMobile
-        className={"fixed bottom-0 w-full md:hidden"}
+        className={"fixed bottom-0 w-full md:hidden z-50"}
         label={"Bereich"}
         currentPageTitle={"Anwaltliche Vertretung"}
+        navItems={props.navItems}
       />
       <NavigationList
         {...props}

--- a/app/components/navigation/NavigationList.tsx
+++ b/app/components/navigation/NavigationList.tsx
@@ -9,13 +9,14 @@ export type NavigationA11yLabels = {
 export type FlowNavigationProps = Readonly<{
   navItems: NavItem[];
   a11yLabels?: NavigationA11yLabels;
+  className?: string;
 }>;
 
 export const NavigationList = ({
   navItems,
   ...props
 }: FlowNavigationProps & { isChild?: boolean }) => (
-  <ul className="pl-0">
+  <ul className={`pl-0 ${props.className ?? ""}`}>
     {navItems.map((navItem) => (
       <NavItem {...navItem} key={navItem.destination} {...props} />
     ))}

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -1,22 +1,31 @@
 import MenuIcon from "@digitalservicebund/icons/Menu";
+import { NavigationList } from "~/components/navigation/NavigationList";
+import { NavItem } from "~/components/navigation/NavItem";
 
 type SideNavMobileProps = Readonly<{
   className?: string;
   label: string;
   currentPageTitle: string;
+  navItems: NavItem[];
 }>;
 
 export default function SideNavMobile(props: SideNavMobileProps) {
   return (
-    <button
-      type="button"
-      className={`flex flex-wrap items-center justify-start gap-8 text-sm py-16 px-10 bg-white border-[1px] border-blue-400 ${props.className ?? ""}`}
-    >
-      <MenuIcon className={"!h-[24px] !w-[24px]"} />
-      <span>
-        {props.label}:
-        <span className={"font-semibold"}> {props.currentPageTitle} </span>
-      </span>
-    </button>
+    <div className={props.className}>
+      <input type="checkbox" id="menu-toggle" className="peer hidden" />
+      <label
+        htmlFor="menu-toggle"
+        className={`flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer`}
+      >
+        <MenuIcon className="!h-[24px] !w-[24px]" />
+        <span>
+          {props.label}:{" "}
+          <span className="font-semibold">{props.currentPageTitle}</span>
+        </span>
+      </label>
+      <div className="w-full hidden peer-checked:block bg-white">
+        <NavigationList navItems={props.navItems} />
+      </div>
+    </div>
   );
 }

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -11,7 +11,7 @@ type SideNavMobileProps = Readonly<{
 
 export default function SideNavMobile(props: SideNavMobileProps) {
   return (
-    <div className={props.className}>
+    <div className={props.className ?? ""}>
       <input type="checkbox" id="menu-toggle" className="peer hidden" />
       <div
         className={"bg-black h-screen opacity-70 hidden peer-checked:block"}
@@ -26,8 +26,10 @@ export default function SideNavMobile(props: SideNavMobileProps) {
           <span className="font-semibold">{props.currentPageTitle}</span>
         </span>
       </label>
-      <div className="w-full hidden peer-checked:block bg-white">
-        <NavigationList navItems={props.navItems} />
+      <div className="w-full hidden peer-checked:block bg-white text-[14px]">
+        <div className={"bg-white border border-blue-400 mx-10 mb-10"}>
+          <NavigationList navItems={props.navItems} />
+        </div>
       </div>
     </div>
   );

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -1,0 +1,22 @@
+import MenuIcon from "@digitalservicebund/icons/Menu";
+
+type SideNavMobileProps = Readonly<{
+  className?: string;
+  label: string;
+  currentPageTitle: string;
+}>;
+
+export default function SideNavMobile(props: SideNavMobileProps) {
+  return (
+    <button
+      type="button"
+      className={`flex flex-wrap items-center justify-start gap-8 text-sm py-16 px-10 bg-white border-[1px] border-blue-400 ${props.className ?? ""}`}
+    >
+      <MenuIcon className={"!h-[24px] !w-[24px]"} />
+      <span>
+        {props.label}:
+        <span className={"font-semibold"}> {props.currentPageTitle} </span>
+      </span>
+    </button>
+  );
+}

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -13,6 +13,9 @@ export default function SideNavMobile(props: SideNavMobileProps) {
   return (
     <div className={props.className}>
       <input type="checkbox" id="menu-toggle" className="peer hidden" />
+      <div
+        className={"bg-black h-screen opacity-70 hidden peer-checked:block"}
+      ></div>
       <label
         htmlFor="menu-toggle"
         className={`flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer`}

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -1,3 +1,4 @@
+import Close from "@digitalservicebund/icons/Close";
 import MenuIcon from "@digitalservicebund/icons/Menu";
 import { NavigationList } from "~/components/navigation/NavigationList";
 import { NavItem } from "~/components/navigation/NavItem";
@@ -16,17 +17,22 @@ export default function SideNavMobile(props: SideNavMobileProps) {
       <div
         className={"bg-black h-screen opacity-70 hidden peer-checked:block"}
       ></div>
+
+      <MenuIcon className="inline-flex peer-checked:hidden pl-10 h-[52px] w-1/12 bg-white cursor-pointer text-blue-800" />
+      <Close className="hidden peer-checked:inline-flex pl-10 h-[52px] w-1/12 bg-white cursor-pointer text-blue-800" />
+
       <label
         htmlFor="menu-toggle"
-        className={`flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer`}
+        aria-label="Main menu toggle"
+        className={`inline-flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer w-11/12`}
       >
-        <MenuIcon className="!h-[24px] !w-[24px]" />
         <span>
           {props.label}:{" "}
           <span className="font-semibold">{props.currentPageTitle}</span>
         </span>
       </label>
-      <div className="w-full hidden peer-checked:block bg-white text-[14px]">
+
+      <div className="w-full hidden peer-checked:block bg-white pb-10">
         <div className={"bg-white border border-blue-400 mx-10 mb-10"}>
           <NavigationList navItems={props.navItems} />
         </div>

--- a/app/components/navigation/SideNavMobile.tsx
+++ b/app/components/navigation/SideNavMobile.tsx
@@ -14,9 +14,14 @@ export default function SideNavMobile(props: SideNavMobileProps) {
   return (
     <div className={props.className ?? ""}>
       <input type="checkbox" id="menu-toggle" className="peer hidden" />
-      <div
-        className={"bg-black h-screen opacity-70 hidden peer-checked:block"}
-      ></div>
+
+      <label
+        htmlFor="menu-toggle"
+        className="bg-black h-screen opacity-70 hidden peer-checked:block"
+        aria-label="Close menu"
+      >
+        <span className="sr-only">Close menu</span>
+      </label>
 
       <MenuIcon className="inline-flex peer-checked:hidden pl-10 h-[52px] w-1/12 bg-white cursor-pointer text-blue-800" />
       <Close className="hidden peer-checked:inline-flex pl-10 h-[52px] w-1/12 bg-white cursor-pointer text-blue-800" />
@@ -24,7 +29,7 @@ export default function SideNavMobile(props: SideNavMobileProps) {
       <label
         htmlFor="menu-toggle"
         aria-label="Main menu toggle"
-        className={`inline-flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer w-11/12`}
+        className="inline-flex gap-8 text-sm py-16 px-10 bg-white cursor-pointer w-11/12"
       >
         <span>
           {props.label}:{" "}
@@ -33,7 +38,7 @@ export default function SideNavMobile(props: SideNavMobileProps) {
       </label>
 
       <div className="w-full hidden peer-checked:block bg-white pb-10">
-        <div className={"bg-white border border-blue-400 mx-10 mb-10"}>
+        <div className="bg-white border border-blue-400 mx-10 mb-10">
           <NavigationList navItems={props.navItems} />
         </div>
       </div>

--- a/app/components/navigation/__test__/FlowNavigation.test.tsx
+++ b/app/components/navigation/__test__/FlowNavigation.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import FlowNavigation from "~/components/navigation/FlowNavigation";
 import { NavState } from "~/services/navigation/navState";
 
+// TODO: Test scenario of different viewports
 describe("FlowNavigation", () => {
   it("renders a navigation element", () => {
     const navItems = [
@@ -15,6 +16,6 @@ describe("FlowNavigation", () => {
     render(<FlowNavigation navItems={navItems} />);
 
     const nav = screen.getByRole("navigation");
-    expect(nav).toHaveClass("bg-white border-[1px] border-blue-400");
+    expect(nav).toBeInTheDocument();
   });
 });

--- a/app/routes/shared/components/FormFlowPage.tsx
+++ b/app/routes/shared/components/FormFlowPage.tsx
@@ -46,7 +46,7 @@ export function FormFlowPage() {
     <FormFlowContext.Provider value={formFlowMemo}>
       <Background backgroundColor="blue">
         <div className="pt-32 min-h-screen flex flex-col-reverse justify-end md:flex-wrap md:flex-row md:justify-start">
-          <div className="pb-48 mx-32 md:w-[248px] md:mr-0 md:mt-[1.65rem]">
+          <div className="md:w-[248px] md:mr-0 md:mt-[1.65rem]">
             <FlowNavigation
               navItems={navItems}
               a11yLabels={navigationA11yLabels}


### PR DESCRIPTION
Implement mobile-only SideNav to match the [design](https://www.figma.com/design/gKylnLUREaPll4hBqWCrTl/Ready-To-Send?node-id=26137-23459&t=7llGO4pHBEDzfqJS-0) 

**Functionality:**
- The dropdown menu displays all available pages/sections of the flow.
- The UI element always shows the current menu/nav item to the user is atm.

**Usability:**
- The visual appearance and experience of the menu items are the same as the desktop or tablet version.
- Tapping on the UI element opens the menu.
- Tapping on the dark backdrop closes the menu.
- The whole UI element serves as one big tap-able area that activates the open or close mechanism.
- The menu icon is shown on closed-state. The close icon is shown on open-state.

**Accessibility:**
- The dropdown menu is accessible
- The sidenav is built without javascript