### PR TITLE
fix(Posthog Capture Text): add maskTextSelector to PostHog init

### DIFF
--- a/app/components/cookieBanner/CookieBanner.tsx
+++ b/app/components/cookieBanner/CookieBanner.tsx
@@ -38,6 +38,11 @@ export function CookieBanner({
       posthog.init(POSTHOG_API_KEY, {
         api_host: POSTHOG_API_HOST,
 
+        session_recording: {
+          // Masking text elements to prevent sensitive data being shown in summary/array pages
+          maskTextSelector: "*",
+        },
+
         cross_subdomain_cookie: false, // set cookie for subdomain only
 
         opt_out_persistence_by_default: true,

--- a/app/components/cookieBanner/CookieBanner.tsx
+++ b/app/components/cookieBanner/CookieBanner.tsx
@@ -39,7 +39,7 @@ export function CookieBanner({
         api_host: POSTHOG_API_HOST,
 
         session_recording: {
-          // Masking text elements to prevent sensitive data being shown in summary/array pages
+          // Masking text elements to prevent sensitive data being shown on pages
           maskTextSelector: "*",
         },
 


### PR DESCRIPTION
This PR implements maskTextSelector to session recording in posthog init. It prevents sensitive data being shown in summary/array pages 
