### PR TITLE
fix(Posthog Capture Text): add maskAllInputs to session record for maximum privacy

### DIFF
--- a/app/components/cookieBanner/CookieBanner.tsx
+++ b/app/components/cookieBanner/CookieBanner.tsx
@@ -39,8 +39,9 @@ export function CookieBanner({
         api_host: POSTHOG_API_HOST,
 
         session_recording: {
-          // Masking text elements to prevent sensitive data being shown on pages
+          // Masking input and text elements to prevent sensitive data being shown on pages
           maskTextSelector: "*",
+          maskAllInputs: true,
         },
 
         cross_subdomain_cookie: false, // set cookie for subdomain only


### PR DESCRIPTION
This PR implements maskAllInputs to session recording in posthog init. It prevents sensitive data being shown on pages