### PR TITLE
refactor(iban): replace ibantools by validator/iban

### DIFF
--- a/app/services/validation/__test__/iban.test.ts
+++ b/app/services/validation/__test__/iban.test.ts
@@ -19,10 +19,6 @@ describe("iban validation", () => {
         expected: "KW81CBKU0000000000001234560101",
       },
       {
-        input: " RU0204452560040702810412345678901",
-        expected: "RU0204452560040702810412345678901",
-      },
-      {
         input: " NO8330001234567 ",
         expected: "NO8330001234567",
       },
@@ -46,6 +42,10 @@ describe("iban validation", () => {
       { input: "foobar ", errorMessage: "invalid_iban_format" },
       { input: "DE9110000000012345678", errorMessage: "invalid_iban_format" },
       { input: "DE911000000001234567891", errorMessage: "invalid_iban_format" },
+      {
+        input: "RU0204452560040702810412345678901",
+        errorMessage: "invalid_iban_format",
+      },
       { input: "randomtext", errorMessage: "invalid_iban_format" },
       { input: "DE92100000000123456789", errorMessage: "invalid_iban_format" },
     ];

--- a/app/services/validation/__test__/iban.test.ts
+++ b/app/services/validation/__test__/iban.test.ts
@@ -5,17 +5,16 @@ describe("iban validation", () => {
   describe("success cases", () => {
     const cases = [
       {
-        input: " De 91 1000 0000 0123456789",
-        expected: "DE91100000000123456789",
+        input: "DE14100205001234567890",
+        expected: "DE14100205001234567890",
       },
       {
-        input: " DE 91 1000 0000 0123456789 ",
-        expected: "DE91100000000123456789",
+        input: " DE14 1002 0500 1234 5678 90 ",
+        expected: "DE14100205001234567890",
       },
-      { input: "de91100000000123456789 ", expected: "DE91100000000123456789" },
-      { input: " DE91100000000123456789 ", expected: "DE91100000000123456789" },
+      { input: "de14100205001234567890", expected: "DE14100205001234567890" },
       {
-        input: "KW81CBKU0000000000001234560101",
+        input: "KW81 CBKU000000000000 1234560101",
         expected: "KW81CBKU0000000000001234560101",
       },
       {
@@ -36,18 +35,11 @@ describe("iban validation", () => {
   describe("failing cases", () => {
     const cases = [
       { input: "", errorMessage: "invalid_iban_format" },
-      { input: "DE", errorMessage: "invalid_iban_format" },
-      { input: "123DE", errorMessage: "invalid_iban_format" },
-      { input: " :) ", errorMessage: "invalid_iban_format" },
-      { input: "foobar ", errorMessage: "invalid_iban_format" },
-      { input: "DE9110000000012345678", errorMessage: "invalid_iban_format" },
-      { input: "DE911000000001234567891", errorMessage: "invalid_iban_format" },
-      {
-        input: "RU0204452560040702810412345678901",
-        errorMessage: "invalid_iban_format",
-      },
-      { input: "randomtext", errorMessage: "invalid_iban_format" },
-      { input: "DE92100000000123456789", errorMessage: "invalid_iban_format" },
+      { input: "foobar", errorMessage: "invalid_iban_format" },
+      { input: "DE1410020500123456789", errorMessage: "invalid_iban_format" },
+      { input: "DE14100205001234567891", errorMessage: "invalid_iban_format" },
+      { input: "DE141002050012345678901", errorMessage: "invalid_iban_format" },
+      { input: "NO8330001234568", errorMessage: "invalid_iban_format" },
     ];
 
     test.each(cases)(

--- a/app/services/validation/iban.ts
+++ b/app/services/validation/iban.ts
@@ -1,8 +1,11 @@
 import isIBAN from "validator/lib/isIBAN";
 import { z } from "zod";
 
+// @ts-expect-error 'validator' is using non-standard ESM exports, which forces us to unpack one nested "default" property in Node
+const isIbanCheck = isIBAN.default ?? isIBAN;
+
 export const ibanSchema = z
   .string()
   .toUpperCase()
   .transform((ibanInput) => ibanInput.replaceAll(" ", ""))
-  .refine(isIBAN, { message: "invalid_iban_format" });
+  .refine(isIbanCheck, { message: "invalid_iban_format" });

--- a/app/services/validation/iban.ts
+++ b/app/services/validation/iban.ts
@@ -1,10 +1,8 @@
-import { isValidIBAN } from "ibantools";
+import isIBAN from "validator/lib/isIBAN";
 import { z } from "zod";
 
 export const ibanSchema = z
   .string()
   .toUpperCase()
   .transform((ibanInput) => ibanInput.replaceAll(" ", ""))
-  .refine(isValidIBAN, {
-    message: "invalid_iban_format",
-  });
+  .refine(isIBAN, { message: "invalid_iban_format" });

--- a/data/opensource-licenses.json
+++ b/data/opensource-licenses.json
@@ -185,14 +185,6 @@
     "licenseFile": "a2j-rechtsantragstelle/node_modules/html-entities/LICENSE",
     "direct": true
   },
-  "ibantools": {
-    "licenses": "MIT*",
-    "repository": "https://github.com/Simplify/ibantools",
-    "publisher": "Saša Jovanić",
-    "path": "a2j-rechtsantragstelle/node_modules/ibantools",
-    "licenseFile": "a2j-rechtsantragstelle/node_modules/ibantools/LICENSE",
-    "direct": true
-  },
   "ioredis": {
     "licenses": "MIT",
     "repository": "https://github.com/luin/ioredis",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "fflate": "^0.8.2",
         "haversine-distance": "1.2.3",
         "html-entities": "^2.5.3",
-        "ibantools": "^4.5.1",
         "ioredis": "^5.6.0",
         "isbot": "^5.1.25",
         "lodash": "^4.17.21",
@@ -12434,12 +12433,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ibantools": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/ibantools/-/ibantools-4.5.1.tgz",
-      "integrity": "sha512-DfKQpLlFq9yEUIEnFuCJzss3XavD7iHZTU5PyqXiAJ+rmaMp+NFP3hboumHKuK8nZjuOJg93WemTzcQ5b9jOZA==",
-      "license": "MIT or MPL-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "fflate": "^0.8.2",
     "haversine-distance": "1.2.3",
     "html-entities": "^2.5.3",
-    "ibantools": "^4.5.1",
     "ioredis": "^5.6.0",
     "isbot": "^5.1.25",
     "lodash": "^4.17.21",


### PR DESCRIPTION
- as in title: replaces `ibantools` with existing `validator/iban`
- moves an invalid IBAN to failing tests