### PR TITLE
fix(textarea): add more meaningful message to stringOptionalSchema

### DIFF
--- a/app/services/validation/stringOptional.ts
+++ b/app/services/validation/stringOptional.ts
@@ -4,5 +4,7 @@ import { TEXTAREA_CHAR_LIMIT } from "./inputlimits";
 export const stringOptionalSchema = z
   .string()
   .trim()
-  .max(TEXTAREA_CHAR_LIMIT, { message: "max" })
+  .max(TEXTAREA_CHAR_LIMIT, {
+    message: `You have reached a limit of ${TEXTAREA_CHAR_LIMIT} characters`,
+  })
   .optional();


### PR DESCRIPTION
This PR implements a meaningful message to stringOptionalSchema in case maxLength is reached.

- An error was added to Strapi 
- The error relation was added to the textareas

Before

![Screenshot 2025-03-27 at 14 19 44](https://github.com/user-attachments/assets/49d53c74-3b0c-451c-8615-b0d1091492c1)

After

![Screenshot 2025-03-27 at 14 19 05](https://github.com/user-attachments/assets/3d682995-f8a5-46a1-9e30-ba853cbe97cd)
