### PR TITLE
Increase abort timeout to 9 seconds

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -18,7 +18,7 @@ import { originFromUrlString } from "./util/originFromUrlString";
 import { stripTrailingSlashFromURL } from "./util/strings";
 export { expressApp } from "./expressApp"; //re-exported to be called from server.js
 
-const ABORT_DELAY = 5000;
+const ABORT_DELAY = 9000;
 const CONNECT_SOURCES = [originFromUrlString(webConfig().SENTRY_DSN)].filter(
   (origin) => origin !== undefined,
 );


### PR DESCRIPTION
### Problem
We are getting time to time the error below in our cluster. Throwing this exception might cause some memory leak and making your server slower, causing issues in the application

<img width="920" alt="image" src="https://github.com/user-attachments/assets/eb83d030-bee2-48f0-9f6f-2615e61ec8d1" />

### Solution
Increase timeout from 5 to 9 seconds to before to abort the stream remix request

### Not solved
You can still see this issue when you run the application locally with the dev server and request data direct from Strapi, but running with production server or using a File instead of requesting Strapi directly, the issue is solved