### PR TITLE
Add command to sign image when deploys content deployment

### DIFF
--- a/.github/workflows/build-content.yml
+++ b/.github/workflows/build-content.yml
@@ -55,6 +55,7 @@ jobs:
       - run: ./docker.sh --push content
       - run: ./docker.sh --build prod
       - run: ./docker.sh --push prod
+      - run: ./docker.sh --sign
       - id: prod_image_tag
         run: echo "prod_image_tag=$(./docker.sh --prodImageTag)" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
We are getting this error after we run the content deployment

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/bed00183-c463-4d00-9014-aa9f09800f73" />
