### PR TITLE
refactor(Accordion): move JS into parent

### DIFF
--- a/app/components/Accordion.tsx
+++ b/app/components/Accordion.tsx
@@ -19,24 +19,26 @@ export default function Accordion({ items }: AccordionProps) {
 
   return (
     <section className="border-2 rounded-lg border-blue-500">
-      {items.map((item, index) => (
-        <AccordionItem
-          key={item.title}
-          title={item.title}
-          description={item.description}
-          labels={labels}
-          ref={(el) => {
-            if (el) itemsRef.current[index] = el;
-          }}
-          onSummaryClick={(event) =>
-            itemsRef.current
-              .filter((item) => item !== event.currentTarget.parentElement)
-              .forEach((item) => {
-                item.open = false;
-              })
-          }
-        />
-      ))}
+      {items
+        .filter((item) => item.title || item.description)
+        .map((item, index) => (
+          <AccordionItem
+            key={item.title}
+            title={item.title}
+            description={item.description}
+            labels={labels}
+            ref={(el) => {
+              if (el) itemsRef.current[index] = el;
+            }}
+            onSummaryClick={(event) =>
+              itemsRef.current
+                .filter((item) => item !== event.currentTarget.parentElement)
+                .forEach((item) => {
+                  item.open = false;
+                })
+            }
+          />
+        ))}
     </section>
   );
 }

--- a/app/components/Accordion.tsx
+++ b/app/components/Accordion.tsx
@@ -18,7 +18,8 @@ export default function Accordion({ items }: AccordionProps) {
   };
 
   return (
-    <section className="border-2 rounded-lg border-blue-500">
+    // without overflow-hidden the rounded borders are overwritten by square content edges
+    <section className="border-2 rounded-lg border-blue-500 overflow-hidden">
       {items
         .filter((item) => item.title || item.description)
         .map((item, index) => (

--- a/app/components/Accordion.tsx
+++ b/app/components/Accordion.tsx
@@ -1,5 +1,9 @@
 import { useRef } from "react";
-import AccordionItem, { type AccordionItemProps } from "./AccordionItem";
+import AccordionItem, {
+  type AccordionItemProps,
+} from "~/components/AccordionItem";
+import { getTranslationByKey } from "~/services/translations/getTranslationByKey";
+import { useTranslations } from "~/services/translations/translationsContext";
 
 export type AccordionProps = Readonly<{
   items: AccordionItemProps[];
@@ -7,6 +11,11 @@ export type AccordionProps = Readonly<{
 
 export default function Accordion({ items }: AccordionProps) {
   const itemsRef = useRef<HTMLDetailsElement[]>([]);
+  const { accordion } = useTranslations();
+  const labels = {
+    show: getTranslationByKey("accordionItemShow", accordion),
+    hide: getTranslationByKey("accordionItemHide", accordion),
+  };
 
   return (
     <section className="border-2 rounded-lg border-blue-500">
@@ -15,6 +24,7 @@ export default function Accordion({ items }: AccordionProps) {
           key={item.title}
           title={item.title}
           description={item.description}
+          labels={labels}
           ref={(el) => {
             if (el) itemsRef.current[index] = el;
           }}

--- a/app/components/Accordion.tsx
+++ b/app/components/Accordion.tsx
@@ -1,31 +1,30 @@
-import { useState, useEffect } from "react";
-import AccordionItem, {
-  type AccordionItemProps,
-} from "~/components/AccordionItem";
+import { useRef } from "react";
+import AccordionItem, { type AccordionItemProps } from "./AccordionItem";
 
 export type AccordionProps = Readonly<{
   items: AccordionItemProps[];
 }>;
 
 export default function Accordion({ items }: AccordionProps) {
-  const [jsEnabled, setJsEnabled] = useState<boolean>(false);
-  const [openIndex, setOpenIndex] = useState<number>(-1);
-
-  useEffect(() => {
-    setJsEnabled(true);
-  }, []);
+  const itemsRef = useRef<HTMLDetailsElement[]>([]);
 
   return (
     <section className="border-2 rounded-lg border-blue-500">
       {items.map((item, index) => (
         <AccordionItem
-          key={item.id ?? index}
-          id={item.id}
+          key={item.title}
           title={item.title}
           description={item.description}
-          isOpen={openIndex === index}
-          onToggle={() => setOpenIndex((prev) => (prev === index ? -1 : index))}
-          jsEnabled={jsEnabled}
+          ref={(el) => {
+            if (el) itemsRef.current[index] = el;
+          }}
+          onSummaryClick={(event) =>
+            itemsRef.current
+              .filter((item) => item !== event.currentTarget.parentElement)
+              .forEach((item) => {
+                item.open = false;
+              })
+          }
         />
       ))}
     </section>

--- a/app/components/AccordionItem.tsx
+++ b/app/components/AccordionItem.tsx
@@ -1,70 +1,36 @@
 import KeyboardArrowDownIcon from "@digitalservicebund/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@digitalservicebund/icons/KeyboardArrowUp";
+import { forwardRef, type MouseEventHandler } from "react";
 import RichText from "~/components/RichText";
 import { useTranslations } from "~/services/translations/translationsContext";
-
-export type Props = AccordionItemProps &
-  Readonly<{
-    isOpen: boolean;
-    onToggle: () => void;
-    jsEnabled: boolean;
-  }>;
 
 export type AccordionItemProps = Readonly<{
   title: string;
   description: string;
-  id: number;
 }>;
 
-export default function AccordionItem({
-  title,
-  description,
-  isOpen,
-  onToggle,
-  jsEnabled,
-}: Props) {
+export default forwardRef<
+  HTMLDetailsElement,
+  AccordionItemProps & { onSummaryClick?: MouseEventHandler }
+>(function AccordionItem({ title, description, onSummaryClick }, ref) {
   const { accordion } = useTranslations();
-
-  // When JS is enabled, intercept clicks on the summary to prevent
-  // the default native toggle behavior and instead call the parent's handler.
-  const handleSummaryClick = (event: React.MouseEvent) => {
-    if (jsEnabled) {
-      event.preventDefault();
-      onToggle();
-    }
-  };
 
   return (
     <details
-      className="group last:border-b-0 border-b-2 p-2 border-blue-500 align-middle"
-      // When JS is enabled, control the open state via the parent's state.
-      {...(jsEnabled ? { open: isOpen } : {})}
+      className="group border last:border-b-0 border-b-2 p-2 border-blue-500 align-middle"
+      ref={ref}
     >
       <summary
-        onClick={handleSummaryClick}
+        onClick={onSummaryClick}
         className="flex align-middle justify-between cursor-pointer p-16 bg-blue-100"
+        role="button"
       >
         <span className="ds-label-01-bold">{title}</span>
-        <span className="align-middle text-blue-800 ds-label-03-bold">
-          {jsEnabled ? (
-            <>
-              <span className={isOpen ? "flex" : "hidden"}>
-                <KeyboardArrowUpIcon /> {accordion.accordionItemHide}
-              </span>
-              <span className={!isOpen ? "flex" : "hidden"}>
-                <KeyboardArrowDownIcon /> {accordion.accordionItemShow}
-              </span>
-            </>
-          ) : (
-            <>
-              <span className="flex group-open:hidden">
-                <KeyboardArrowDownIcon /> {accordion.accordionItemShow}
-              </span>
-              <span className="hidden group-open:flex">
-                <KeyboardArrowUpIcon /> {accordion.accordionItemHide}
-              </span>
-            </>
-          )}
+        <span className="flex group-open:hidden text-blue-800">
+          <KeyboardArrowDownIcon /> {accordion?.accordionItemShow}
+        </span>
+        <span className="hidden group-open:flex text-blue-800">
+          <KeyboardArrowUpIcon /> {accordion?.accordionItemHide}
         </span>
       </summary>
       <RichText
@@ -73,4 +39,4 @@ export default function AccordionItem({
       />
     </details>
   );
-}
+});

--- a/app/components/AccordionItem.tsx
+++ b/app/components/AccordionItem.tsx
@@ -2,7 +2,6 @@ import KeyboardArrowDownIcon from "@digitalservicebund/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@digitalservicebund/icons/KeyboardArrowUp";
 import { forwardRef, type MouseEventHandler } from "react";
 import RichText from "~/components/RichText";
-import { useTranslations } from "~/services/translations/translationsContext";
 
 export type AccordionItemProps = Readonly<{
   title: string;
@@ -11,10 +10,14 @@ export type AccordionItemProps = Readonly<{
 
 export default forwardRef<
   HTMLDetailsElement,
-  AccordionItemProps & { onSummaryClick?: MouseEventHandler }
->(function AccordionItem({ title, description, onSummaryClick }, ref) {
-  const { accordion } = useTranslations();
-
+  AccordionItemProps & {
+    onSummaryClick?: MouseEventHandler;
+    labels: {
+      show: string;
+      hide: string;
+    };
+  }
+>(function AccordionItem({ title, description, onSummaryClick, labels }, ref) {
   return (
     <details
       className="group border last:border-b-0 border-b-2 p-2 border-blue-500 align-middle"
@@ -27,10 +30,10 @@ export default forwardRef<
       >
         <span className="ds-label-01-bold">{title}</span>
         <span className="flex group-open:hidden text-blue-800">
-          <KeyboardArrowDownIcon /> {accordion?.accordionItemShow}
+          <KeyboardArrowDownIcon /> {labels.show}
         </span>
         <span className="hidden group-open:flex text-blue-800">
-          <KeyboardArrowUpIcon /> {accordion?.accordionItemHide}
+          <KeyboardArrowUpIcon /> {labels.hide}
         </span>
       </summary>
       <RichText

--- a/app/components/AccordionItem.tsx
+++ b/app/components/AccordionItem.tsx
@@ -20,19 +20,19 @@ export default forwardRef<
 >(function AccordionItem({ title, description, onSummaryClick, labels }, ref) {
   return (
     <details
-      className="group border last:border-b-0 border-b-2 p-2 border-blue-500 align-middle"
+      className="group last:border-b-0 border-b-2 border-blue-500"
       ref={ref}
     >
       <summary
         onClick={onSummaryClick}
-        className="flex align-middle justify-between cursor-pointer p-16 bg-blue-100"
+        className="flex justify-between cursor-pointer p-16 bg-blue-100 "
         role="button"
       >
         <span className="ds-label-01-bold">{title}</span>
-        <span className="flex group-open:hidden text-blue-800">
+        <span className="flex group-open:hidden text-blue-800 ds-label-03-bold items-center">
           <KeyboardArrowDownIcon /> {labels.show}
         </span>
-        <span className="hidden group-open:flex text-blue-800">
+        <span className="hidden group-open:flex text-blue-800 ds-label-03-bold items-center">
           <KeyboardArrowUpIcon /> {labels.hide}
         </span>
       </summary>

--- a/app/components/ListItem.tsx
+++ b/app/components/ListItem.tsx
@@ -54,7 +54,7 @@ const ListItem = ({
           <div className="w-2 h-full group-last:hidden bg-blue-500"></div>
         )}
       </div>
-      <div className="ds-stack ds-stack-24 pb-48">
+      <div className="ds-stack ds-stack-24 pb-48 w-full">
         <div className="ds-stack ds-stack-8">
           {headline && <Heading {...headline} />}
           {content && <RichText html={content} />}

--- a/app/components/__test__/Accordion.test.tsx
+++ b/app/components/__test__/Accordion.test.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from "@testing-library/react";
+import { useTranslations } from "~/services/translations/translationsContext";
 import Accordion from "../Accordion";
 import type { AccordionItemProps } from "../AccordionItem";
 
@@ -42,5 +43,24 @@ describe("Accordion Component", () => {
     expect(descriptions[0]).not.toBeVisible();
     expect(descriptions[1]).not.toBeVisible();
     expect(descriptions[2]).not.toBeVisible();
+  });
+
+  vi.mock("~/services/translations/translationsContext", () => ({
+    useTranslations: vi.fn(),
+  }));
+
+  vi.mocked(useTranslations).mockReturnValue({
+    feedback: {},
+    video: {},
+    accessibility: {},
+    fileUpload: {},
+    accordion: {
+      accordionItemShow: "Einblenden",
+      accordionItemHide: "Ausblenden",
+    },
+  });
+  it("applies translations", () => {
+    const { getAllByText } = render(<Accordion items={dummyItems} />);
+    getAllByText("Einblenden").forEach((el) => expect(el).toBeVisible());
   });
 });

--- a/app/components/__test__/Accordion.test.tsx
+++ b/app/components/__test__/Accordion.test.tsx
@@ -1,88 +1,46 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { vi } from "vitest";
-import type { AccordionItemProps } from "~/components/AccordionItem";
+import { render, fireEvent } from "@testing-library/react";
 import Accordion from "../Accordion";
+import type { AccordionItemProps } from "../AccordionItem";
 
 const dummyItems = [
-  { title: "Item 1", description: "Description 1", id: 1 },
-  { title: "Item 2", description: "Description 2", id: 2 },
-  { title: "Item 3", description: "Description 3", id: 3 },
-];
-
-vi.mock("~/components/AccordionItem", () => ({
-  __esModule: true,
-  default: ({
-    title,
-    description,
-    isOpen,
-    onToggle,
-    jsEnabled,
-    id,
-  }: AccordionItemProps & {
-    isOpen: boolean;
-    onToggle: () => void;
-    jsEnabled: boolean;
-    id: number;
-  }) => (
-    <div data-testid="accordion-item">
-      <div data-testid="accordion-title">{title}</div>
-      <div data-testid="accordion-description">{isOpen ? description : ""}</div>
-      <button data-testid="accordion-toggle" onClick={onToggle}>
-        Toggle
-      </button>
-      <div data-testid="js-enabled">{jsEnabled ? "true" : "false"}</div>
-      <div data-testid="accordion-item-id">{id}</div>
-    </div>
-  ),
-}));
+  { title: "Item 1", description: "Description 1" },
+  { title: "Item 2", description: "Description 2" },
+  { title: "Item 3", description: "Description 3" },
+] as const satisfies AccordionItemProps[];
 
 describe("Accordion Component", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("renders the correct number of AccordionItem components", () => {
-    render(<Accordion items={dummyItems} />);
-    const accordionItems = screen.getAllByTestId("accordion-item");
-    expect(accordionItems).toHaveLength(dummyItems.length);
-  });
-
-  it("passes jsEnabled as true to each AccordionItem after mount", () => {
-    render(<Accordion items={dummyItems} />);
-    const jsEnabledIndicators = screen.getAllByTestId("js-enabled");
-    jsEnabledIndicators.forEach((indicator) => {
-      expect(indicator).toHaveTextContent("true");
-    });
+    const { getAllByRole } = render(<Accordion items={dummyItems} />);
+    const summaries = getAllByRole("button");
+    const descriptions = getAllByRole("group");
+    expect(summaries).toHaveLength(dummyItems.length);
+    expect(descriptions).toHaveLength(dummyItems.length);
   });
 
   it("allows toggling so that only one AccordionItem is open at a time", () => {
-    render(<Accordion items={dummyItems} />);
-    const toggleButtons = screen.getAllByTestId("accordion-toggle");
-    const descriptions = screen.getAllByTestId("accordion-description");
+    const { getAllByRole } = render(<Accordion items={dummyItems} />);
+    const summaries = getAllByRole("button");
+    const descriptions = getAllByRole("group").map(
+      (item) => item.childNodes[1],
+    );
 
     descriptions.forEach((desc) => {
-      expect(desc.textContent).toBe("");
+      expect(desc).not.toBeVisible();
     });
 
-    fireEvent.click(toggleButtons[0]);
-    expect(descriptions[0].textContent).toBe("Description 1");
-    expect(descriptions[1].textContent).toBe("");
-    expect(descriptions[2].textContent).toBe("");
+    fireEvent.click(summaries[0]);
+    expect(descriptions[0]).toBeVisible();
+    expect(descriptions[1]).not.toBeVisible();
+    expect(descriptions[2]).not.toBeVisible();
 
-    fireEvent.click(toggleButtons[1]);
-    expect(descriptions[0].textContent).toBe("");
-    expect(descriptions[1].textContent).toBe("Description 2");
-    expect(descriptions[2].textContent).toBe("");
+    fireEvent.click(summaries[1]);
+    expect(descriptions[0]).not.toBeVisible();
+    expect(descriptions[1]).toBeVisible();
+    expect(descriptions[2]).not.toBeVisible();
 
-    fireEvent.click(toggleButtons[1]);
-    expect(descriptions[1].textContent).toBe("");
-  });
-
-  it("renders AccordionItem with the correct id", () => {
-    render(<Accordion items={dummyItems} />);
-    const accordionItemIds = screen.getAllByTestId("accordion-item-id");
-    expect(accordionItemIds[0]).toHaveTextContent("1");
-    expect(accordionItemIds[1]).toHaveTextContent("2");
-    expect(accordionItemIds[2]).toHaveTextContent("3");
+    fireEvent.click(summaries[1]);
+    expect(descriptions[0]).not.toBeVisible();
+    expect(descriptions[1]).not.toBeVisible();
+    expect(descriptions[2]).not.toBeVisible();
   });
 });

--- a/app/components/__test__/Accordion.test.tsx
+++ b/app/components/__test__/Accordion.test.tsx
@@ -45,6 +45,20 @@ describe("Accordion Component", () => {
     expect(descriptions[2]).not.toBeVisible();
   });
 
+  it("doesn't rendern empty items", () => {
+    const { getAllByRole } = render(
+      <Accordion
+        items={[
+          { title: "title1", description: "" },
+          { title: "", description: "hallo" },
+          { title: "", description: "" },
+        ]}
+      />,
+    );
+    const summaries = getAllByRole("button");
+    expect(summaries).toHaveLength(2);
+  });
+
   vi.mock("~/services/translations/translationsContext", () => ({
     useTranslations: vi.fn(),
   }));

--- a/app/components/__test__/AccordionItem.test.tsx
+++ b/app/components/__test__/AccordionItem.test.tsx
@@ -1,11 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import AccordionItem from "~/components/AccordionItem";
 
-vi.mock("@digitalservicebund/icons/KeyboardArrowDown", () => ({
-  __esModule: true,
-  default: () => <div data-testid="keyboard-arrow-down-icon" />,
-}));
-
 const defaultProps = {
   title: "Test Title",
   description: "Test Description",
@@ -25,7 +20,7 @@ describe("AccordionItem Component", () => {
     expect(summary).toHaveTextContent("Test Title");
     expect(summary).toHaveTextContent("Einblenden");
     expect(summary).toHaveTextContent("Einblenden");
-    // expect(screen.getByTestId("keyboard-arrow-down-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
   });
 
   it("calls onSummary when summary is clicked", () => {

--- a/app/components/__test__/AccordionItem.test.tsx
+++ b/app/components/__test__/AccordionItem.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { vi as vitestVi } from "vitest";
-import AccordionItem, { type Props } from "~/components/AccordionItem";
+import AccordionItem, {
+  type AccordionItemProps,
+} from "~/components/AccordionItem";
 import { useTranslations } from "~/services/translations/translationsContext";
 
 vi.mock("~/services/translations/translationsContext", () => ({
@@ -12,100 +14,49 @@ vi.mock("@digitalservicebund/icons/KeyboardArrowDown", () => ({
   default: () => <div data-testid="keyboard-arrow-down-icon" />,
 }));
 
-vi.mock("@digitalservicebund/icons/KeyboardArrowUp", () => ({
-  __esModule: true,
-  default: () => <div data-testid="keyboard-arrow-up-icon" />,
-}));
+const defaultProps: AccordionItemProps = {
+  title: "Test Title",
+  description: "Test Description",
+};
+
+const mockTranslations = {
+  feedback: {},
+  video: {},
+  accessibility: {},
+  fileUpload: {},
+  accordion: {
+    accordionItemShow: "Einblenden",
+    accordionItemHide: "Ausblenden",
+  },
+};
+
+vitestVi.mocked(useTranslations).mockReturnValue(mockTranslations);
 
 describe("AccordionItem Component", () => {
-  const defaultProps: Props = {
-    title: "Test Title",
-    description: "Test Description",
-    id: 1,
-    isOpen: false,
-    onToggle: vi.fn(),
-    jsEnabled: true,
-  };
-
-  const mockTranslations = {
-    feedback: {},
-    video: {},
-    accessibility: {},
-    fileUpload: {},
-    accordion: {
-      accordionItemShow: "Einblenden",
-      accordionItemHide: "Ausblenden",
-    },
-  };
-
-  vitestVi.mocked(useTranslations).mockReturnValue(mockTranslations);
-
-  describe("JS Enabled Branch", () => {
-    it("renders correctly in closed state", () => {
-      render(<AccordionItem {...defaultProps} />);
-      expect(screen.getByText("Test Title")).toBeInTheDocument();
-      expect(
-        screen.getByTestId("keyboard-arrow-down-icon"),
-      ).toBeInTheDocument();
-      expect(screen.queryByText("Test Description")).not.toBeVisible();
-    });
-
-    it("renders correctly in open state", () => {
-      render(<AccordionItem {...defaultProps} isOpen={true} />);
-      expect(screen.getByText("Test Title")).toBeInTheDocument();
-      expect(screen.getByTestId("keyboard-arrow-up-icon")).toBeInTheDocument();
-      expect(screen.getByText("Test Description")).toBeInTheDocument();
-    });
-
-    it("calls onToggle when summary is clicked", () => {
-      const onToggleMock = vi.fn();
-      render(<AccordionItem {...defaultProps} onToggle={onToggleMock} />);
-      fireEvent.click(
-        screen.getByRole("group", { hidden: true }).querySelector("summary")!,
-      );
-      expect(onToggleMock).toHaveBeenCalledTimes(1);
-    });
+  it("renders native details/summary with translations and icons", () => {
+    render(<AccordionItem {...defaultProps} />);
+    const detailsElem = screen.getByRole("group", { hidden: true });
+    expect(detailsElem).toBeInTheDocument();
+    const summary = detailsElem.querySelector("summary");
+    expect(summary).toBeInTheDocument();
+    expect(summary).toHaveTextContent("Test Title");
+    expect(summary).toHaveTextContent("Einblenden");
+    expect(summary).toHaveTextContent("Einblenden");
+    // expect(screen.getByTestId("keyboard-arrow-down-icon")).toBeInTheDocument();
   });
 
-  describe("Fallback (No JS) Branch", () => {
-    const fallbackProps: Props = {
-      ...defaultProps,
-      jsEnabled: false,
-    };
-
-    it("renders fallback markup using native details/summary with translations and icons", () => {
-      render(<AccordionItem {...fallbackProps} />);
-      const detailsElem = screen.getByRole("group", { hidden: true });
-      expect(detailsElem).toBeInTheDocument();
-      const summary = detailsElem.querySelector("summary");
-      expect(summary).toBeInTheDocument();
-      expect(summary).toHaveTextContent("Test Title");
-      expect(summary).toHaveTextContent("Einblenden");
-      expect(
-        screen.getByTestId("keyboard-arrow-down-icon"),
-      ).toBeInTheDocument();
-    });
-
-    it("renders description when fallback details is open", () => {
-      render(<AccordionItem {...fallbackProps} />);
-      const detailsElem = screen.getByRole("group", { hidden: true });
-      detailsElem.setAttribute("open", "");
-      expect(screen.getByText("Test Description")).toBeInTheDocument();
-    });
-
-    it("renders open state fallback markup with hide translations and icons", () => {
-      render(<AccordionItem {...fallbackProps} />);
-      const detailsElem = screen.getByRole("group", { hidden: true });
-      detailsElem.setAttribute("open", "");
-      const summary = detailsElem.querySelector("summary");
-      expect(summary).toHaveTextContent("Ausblenden");
-      expect(screen.getByTestId("keyboard-arrow-up-icon")).toBeInTheDocument();
-    });
-
-    it("renders correctly with empty title and description", () => {
-      render(<AccordionItem {...fallbackProps} title="" description="" />);
-      const detailsElem = screen.getByRole("group", { hidden: true });
-      expect(detailsElem).toBeInTheDocument();
-    });
+  it("calls onSummary when summary is clicked", () => {
+    const onSummaryClick = vi.fn();
+    const { getByRole } = render(
+      <AccordionItem {...defaultProps} onSummaryClick={onSummaryClick} />,
+    );
+    fireEvent.click(getByRole("button"));
+    expect(onSummaryClick).toHaveBeenCalledTimes(1);
   });
+});
+
+it("renders correctly with empty title and description", () => {
+  render(<AccordionItem title="" description="" />);
+  const detailsElem = screen.getByRole("group", { hidden: true });
+  expect(detailsElem).toBeInTheDocument();
 });

--- a/app/components/__test__/AccordionItem.test.tsx
+++ b/app/components/__test__/AccordionItem.test.tsx
@@ -1,36 +1,19 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { vi as vitestVi } from "vitest";
-import AccordionItem, {
-  type AccordionItemProps,
-} from "~/components/AccordionItem";
-import { useTranslations } from "~/services/translations/translationsContext";
-
-vi.mock("~/services/translations/translationsContext", () => ({
-  useTranslations: vitestVi.fn(),
-}));
+import AccordionItem from "~/components/AccordionItem";
 
 vi.mock("@digitalservicebund/icons/KeyboardArrowDown", () => ({
   __esModule: true,
   default: () => <div data-testid="keyboard-arrow-down-icon" />,
 }));
 
-const defaultProps: AccordionItemProps = {
+const defaultProps = {
   title: "Test Title",
   description: "Test Description",
-};
-
-const mockTranslations = {
-  feedback: {},
-  video: {},
-  accessibility: {},
-  fileUpload: {},
-  accordion: {
-    accordionItemShow: "Einblenden",
-    accordionItemHide: "Ausblenden",
+  labels: {
+    show: "Einblenden",
+    hide: "Ausblenden",
   },
 };
-
-vitestVi.mocked(useTranslations).mockReturnValue(mockTranslations);
 
 describe("AccordionItem Component", () => {
   it("renders native details/summary with translations and icons", () => {
@@ -56,7 +39,7 @@ describe("AccordionItem Component", () => {
 });
 
 it("renders correctly with empty title and description", () => {
-  render(<AccordionItem title="" description="" />);
+  render(<AccordionItem {...defaultProps} title="" description="" />);
   const detailsElem = screen.getByRole("group", { hidden: true });
   expect(detailsElem).toBeInTheDocument();
 });

--- a/app/components/__test__/AccordionItem.test.tsx
+++ b/app/components/__test__/AccordionItem.test.tsx
@@ -37,9 +37,3 @@ describe("AccordionItem Component", () => {
     expect(onSummaryClick).toHaveBeenCalledTimes(1);
   });
 });
-
-it("renders correctly with empty title and description", () => {
-  render(<AccordionItem {...defaultProps} title="" description="" />);
-  const detailsElem = screen.getByRole("group", { hidden: true });
-  expect(detailsElem).toBeInTheDocument();
-});

--- a/app/components/__test__/ListItem.test.tsx
+++ b/app/components/__test__/ListItem.test.tsx
@@ -49,7 +49,7 @@ describe("ListItem", () => {
       <ListItem
         variant="numbered"
         accordion={{
-          items: [{ title: "title", description: "content", id: 1 }],
+          items: [{ title: "title", description: "content" }],
         }}
       />,
     );

--- a/stories/Accordion.stories.tsx
+++ b/stories/Accordion.stories.tsx
@@ -43,19 +43,16 @@ export const Example: Story = {
   args: {
     items: [
       {
-        id: 1,
         title: "Accordion Item 1",
         description:
           "This is the description for accordion item 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
       },
       {
-        id: 2,
         title: "Accordion Item 2",
         description:
           "This is the description for accordion item 2. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       },
       {
-        id: 3,
         title: "Accordion Item 3",
         description:
           "This is the description for accordion item 3. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",


### PR DESCRIPTION
- moves JS into parent
- simplifies tests
- matches design
- filters empty items (both empty text + description)