### PR TITLE
feat(a11y): enable focus on error for radio

### DIFF
--- a/app/components/inputs/InputError.tsx
+++ b/app/components/inputs/InputError.tsx
@@ -1,16 +1,23 @@
 import ErrorOutline from "@digitalservicebund/icons/ErrorOutline";
 import type { PropsWithChildren } from "react";
+import { forwardRef } from "react";
 
 type InputErrorProps = PropsWithChildren<{
   readonly id: string;
+  readonly tabIndex?: number;
 }>;
 
-const InputError = ({ id, children }: InputErrorProps) => {
+function InputError(
+  { id, children, tabIndex }: InputErrorProps,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
   return (
-    <div aria-live="assertive">
+    <div>
       {children && (
         <p
           id={id}
+          ref={ref}
+          tabIndex={tabIndex}
           data-testid="inputError"
           className="mt-4 text-red-800 flex gap-x-4"
         >
@@ -20,6 +27,6 @@ const InputError = ({ id, children }: InputErrorProps) => {
       )}
     </div>
   );
-};
+}
 
-export default InputError;
+export default forwardRef<HTMLDivElement, InputErrorProps>(InputError);

--- a/app/components/inputs/RadioGroup.tsx
+++ b/app/components/inputs/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useState, useEffect, useRef } from "react";
 import { useStringField } from "~/services/validation/useStringField";
 import { type ErrorMessageProps } from ".";
 import InputError from "./InputError";
@@ -25,6 +25,7 @@ const RadioGroup = ({
   formId,
 }: RadioGroupProps) => {
   const { error, defaultValue } = useStringField(name, { formId });
+  const errorRef = useRef<HTMLDivElement>(null);
   const errorId = `${name}-error`;
   const errorToDisplay =
     errorMessages?.find((err) => err.code === error)?.text ?? error;
@@ -33,6 +34,12 @@ const RadioGroup = ({
   const [renderHiddenField, setRenderHiddenField] = useState(
     defaultValue === undefined,
   );
+
+  useEffect(() => {
+    if (errorToDisplay && errorRef.current) {
+      errorRef.current.focus();
+    }
+  }, [errorToDisplay]);
 
   return (
     <fieldset
@@ -56,7 +63,9 @@ const RadioGroup = ({
           />
         ))}
         {errorToDisplay && (
-          <InputError id={errorId}>{errorToDisplay}</InputError>
+          <InputError id={errorId} ref={errorRef} tabIndex={0}>
+            {errorToDisplay}
+          </InputError>
         )}
       </div>
     </fieldset>

--- a/app/components/inputs/__test__/RadioGroup.test.tsx
+++ b/app/components/inputs/__test__/RadioGroup.test.tsx
@@ -1,0 +1,104 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ValidatedForm } from "remix-validated-form";
+import { useStringField } from "~/services/validation/useStringField";
+import RadioGroup from "../RadioGroup";
+
+vi.mock("~/services/validation/useStringField", () => ({
+  useStringField: vi.fn(),
+}));
+
+const createMockStringField = (error?: string) => ({
+  error,
+  defaultValue: undefined,
+  clearError: vi.fn(),
+  validate: vi.fn(),
+  touched: false,
+  setTouched: vi.fn(),
+  getInputProps: vi.fn((props) => ({ ...props })),
+});
+
+const mockOptions = [
+  { value: "option1", text: "Option 1" },
+  { value: "option2", text: "Option 2" },
+];
+
+const mockErrorMessages = [
+  { code: "required", text: "This field is required" },
+];
+
+const renderRadioGroup = (props = {}) => {
+  const RemixStub = createRemixStub([
+    {
+      path: "/",
+      Component: () => (
+        <ValidatedForm validator={{ validate: vi.fn() }} method="post">
+          <RadioGroup
+            name="test"
+            options={mockOptions}
+            label="Test Label"
+            errorMessages={mockErrorMessages}
+            {...props}
+          />
+        </ValidatedForm>
+      ),
+    },
+  ]);
+
+  return render(<RemixStub />);
+};
+
+describe("RadioGroup", () => {
+  beforeEach(() => {
+    vi.mocked(useStringField).mockReturnValue(createMockStringField());
+  });
+
+  it("renders all radio options", () => {
+    renderRadioGroup();
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+  });
+
+  it("renders label when provided", () => {
+    renderRadioGroup();
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("renders alt label when provided", () => {
+    renderRadioGroup({ altLabel: "Alt Label" });
+    expect(screen.getByText("Alt Label")).toBeInTheDocument();
+  });
+
+  it("shows error message when error is present", () => {
+    vi.mocked(useStringField).mockReturnValue(
+      createMockStringField("required"),
+    );
+    renderRadioGroup();
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+  });
+
+  it("focuses error message when it appears", () => {
+    vi.mocked(useStringField).mockReturnValue(
+      createMockStringField("required"),
+    );
+    renderRadioGroup();
+    const errorMessage = screen.getByText("This field is required");
+    expect(errorMessage).toHaveFocus();
+  });
+
+  it("handles radio selection", () => {
+    renderRadioGroup();
+    const radio = screen.getByLabelText("Option 1");
+    fireEvent.click(radio);
+    expect(radio).toBeChecked();
+  });
+
+  it("sets aria-invalid when there is an error", () => {
+    vi.mocked(useStringField).mockReturnValue(
+      createMockStringField("required"),
+    );
+    renderRadioGroup();
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toHaveAttribute("aria-invalid", "true");
+  });
+});


### PR DESCRIPTION
https://app.asana.com/0/1207022303033556/1208646940266128

## TODO
- [ ] needs Marion clarification whether this is for all components that shows error or just Radio
- [ ] Remove live-region

<h2>Before</h2>
<img src="https://github.com/user-attachments/assets/05950747-874b-40a3-9c50-ede348ff1d60" alt="before-output" width="480">

<h2>After</h2>
<img src="https://github.com/user-attachments/assets/b928801b-3976-44b9-a872-678eebbd8cd5" alt="output" width="480">
