### PR TITLE
fix(Wegweiser): Rename page flows 

### DIFF
--- a/app/domains/kontopfaendung/wegweiser/__test__/stringReplacements.test.ts
+++ b/app/domains/kontopfaendung/wegweiser/__test__/stringReplacements.test.ts
@@ -48,8 +48,8 @@ describe("stringReplacements", () => {
   describe("getPrivilegierteForderungStrings", () => {
     it("should return correct Privilegierte Forderung strings", () => {
       const userData: KontopfaendungWegweiserContext = {
-        unerlaubteHandlung: "yes",
-        unterhaltszahlungen: "no",
+        pfaendungStrafe: "yes",
+        pfaendungUnterhalt: "no",
       };
       expect(getPrivilegierteForderungStrings(userData)).toEqual({
         isPrivilegierteForderungStrafe: true,
@@ -238,7 +238,7 @@ describe("stringReplacements", () => {
   describe("getSelbststaendigStrings", () => {
     it("should return correct Selbststaendig strings", () => {
       const userData: KontopfaendungWegweiserContext = {
-        arbeitsweise: {
+        arbeitArt: {
           selbstaendig: CheckboxValue.on,
           angestellt: CheckboxValue.off,
         },
@@ -251,7 +251,7 @@ describe("stringReplacements", () => {
   describe("getAngestelltStrings", () => {
     it("should return correct Angestellt strings", () => {
       const userData: KontopfaendungWegweiserContext = {
-        arbeitsweise: {
+        arbeitArt: {
           angestellt: CheckboxValue.on,
           selbstaendig: CheckboxValue.off,
         },

--- a/app/domains/kontopfaendung/wegweiser/__test__/testcases.ts
+++ b/app/domains/kontopfaendung/wegweiser/__test__/testcases.ts
@@ -14,78 +14,83 @@ const cases = [
     ["/kontopfaendung", "/p-konto", "/p-konto-probleme", "/glaeubiger"],
   ],
   // Glaeubiger
-  [{}, ["/glaeubiger", "/euro-schwelle"]],
+  [{}, ["/glaeubiger", "/sockelbetrag"]],
   [
     {
       schuldenBei: "privat",
     },
-    ["/glaeubiger", "/unterhalts-zahlungen", "/euro-schwelle"],
+    ["/glaeubiger", "/pfaendung-unterhalt", "/sockelbetrag"],
   ],
   [
     {
       schuldenBei: "jugendamt",
     },
-    ["/glaeubiger", "/unterhalts-zahlungen", "/euro-schwelle"],
+    ["/glaeubiger", "/pfaendung-unterhalt", "/sockelbetrag"],
   ],
   [
     {
       schuldenBei: "weissNicht",
     },
-    ["/glaeubiger", "/glaeubiger-unbekannt", "/euro-schwelle"],
+    ["/glaeubiger", "/glaeubiger-unbekannt", "/sockelbetrag"],
   ],
   [
     {
       schuldenBei: "staatsanwaltschaft",
     },
-    ["/glaeubiger", "/unerlaubten-handlung", "/euro-schwelle"],
+    ["/glaeubiger", "/pfaendung-strafe", "/sockelbetrag"],
   ],
   [
     {
       schuldenBei: "kasse",
     },
-    ["/glaeubiger", "/unerlaubten-handlung", "/euro-schwelle"],
+    ["/glaeubiger", "/pfaendung-strafe", "/sockelbetrag"],
   ],
-  // euro-schwelle
+  // sockelbetrag
   [
     {
-      euroSchwelle: "nein",
+      sockelbetrag: "nein",
     },
-    ["/euro-schwelle", "/ergebnis/geringe-einkuenfte"],
+    ["/sockelbetrag", "/ergebnis/geringe-einkuenfte"],
   ],
   [
     {
-      euroSchwelle: "ja",
+      sockelbetrag: "ja",
     },
-    ["/euro-schwelle", "/zwischenseite-unterhalt"],
+    ["/sockelbetrag", "/zwischenseite-unterhalt"],
   ],
   // Unterhalt
   [
     {},
-    ["/zwischenseite-unterhalt", "/kinder", "/partner", "/zwischenseite-cash"],
+    [
+      "/zwischenseite-unterhalt",
+      "/kinder",
+      "/partner",
+      "/zwischenseite-einkuenfte",
+    ],
   ],
   [
     { hasKinder: "yes" },
-    ["/kinder", "/kinder-wohnen-zusammen", "/kinder-support", "/partner"],
+    ["/kinder", "/kinder-wohnen-zusammen", "/kinder-unterhalt", "/partner"],
   ],
   [
     { verheiratet: "ja" },
     [
       "/partner",
       "/partner-wohnen-zusammen",
-      "/partner-support",
-      "/zwischenseite-cash",
+      "/partner-unterhalt",
+      "/zwischenseite-einkuenfte",
     ],
   ],
   [
     { verheiratet: "getrennt" },
-    ["/partner", "/partner-support", "/zwischenseite-cash"],
+    ["/partner", "/partner-unterhalt", "/zwischenseite-einkuenfte"],
   ],
   // Cash
   [
     {},
     [
-      "/zwischenseite-cash",
-      "/ermittlung-betrags",
+      "/zwischenseite-einkuenfte",
+      "/arbeit",
       "/sozialleistungen",
       "/sozialleistungen-umstaende",
       "/ergebnis/naechste-schritte",
@@ -94,20 +99,20 @@ const cases = [
   [
     { hasArbeit: "yes" },
     [
-      "/ermittlung-betrags",
-      "/arbeitsweise",
+      "/arbeit",
+      "/arbeit-art",
       "/nachzahlung-arbeitgeber",
-      "/zahlung-arbeitgeber",
+      "/einmalzahlung-arbeitgeber",
       "/sozialleistungen",
     ],
   ],
   [
     { hasArbeit: "yes", nachzahlungArbeitgeber: "yes" },
     [
-      "/arbeitsweise",
+      "/arbeit-art",
       "/nachzahlung-arbeitgeber",
-      "/zahlungslimit",
-      "/zahlung-arbeitgeber",
+      "/hoehe-nachzahlung-arbeitgeber",
+      "/einmalzahlung-arbeitgeber",
       "/sozialleistungen",
     ],
   ],
@@ -220,7 +225,7 @@ const cases = [
     },
     [
       "/sozialleistung-nachzahlung",
-      "/sozialleistung-nachzahlung-amount",
+      "/hoehe-nachzahlung-sozialleistung",
       "/sozialleistungen-einmalzahlung",
       "/ergebnis/naechste-schritte",
     ],
@@ -230,8 +235,8 @@ const cases = [
       hasKontopfaendung: "ja",
       hasPKonto: "nichtEingerichtet",
       schuldenBei: "privat",
-      unterhaltszahlungen: "yes",
-      euroSchwelle: "ja",
+      pfaendungUnterhalt: "yes",
+      sockelbetrag: "ja",
       hasKinder: "yes",
       kinderUnterhalt: "no",
       verheiratet: "nein",
@@ -252,23 +257,23 @@ const cases = [
       "/p-konto",
       "/p-konto-probleme",
       "/glaeubiger",
-      "/unterhalts-zahlungen",
-      "/euro-schwelle",
+      "/pfaendung-unterhalt",
+      "/sockelbetrag",
       "/zwischenseite-unterhalt",
       "/kinder",
       "/kinder-wohnen-zusammen",
-      "/kinder-support",
+      "/kinder-unterhalt",
       "/partner",
-      "/zwischenseite-cash",
-      "/ermittlung-betrags",
-      "/arbeitsweise",
+      "/zwischenseite-einkuenfte",
+      "/arbeit",
+      "/arbeit-art",
       "/nachzahlung-arbeitgeber",
-      "/zahlungslimit",
-      "/zahlung-arbeitgeber",
+      "/hoehe-nachzahlung-arbeitgeber",
+      "/einmalzahlung-arbeitgeber",
       "/sozialleistungen",
       "/sozialleistungen-umstaende",
       "/sozialleistung-nachzahlung",
-      "/sozialleistung-nachzahlung-amount",
+      "/hoehe-nachzahlung-sozialleistung",
       "/sozialleistungen-einmalzahlung",
     ],
   ],

--- a/app/domains/kontopfaendung/wegweiser/context.ts
+++ b/app/domains/kontopfaendung/wegweiser/context.ts
@@ -34,7 +34,7 @@ const schuldenBei = z.enum(
   customRequiredErrorMessage,
 );
 
-const euroSchwelle = z.enum(
+const sockelbetrag = z.enum(
   ["nein", "ja", "weissNicht", "unterschiedlich"],
   customRequiredErrorMessage,
 );
@@ -49,7 +49,7 @@ const verheiratet = z.enum(
   customRequiredErrorMessage,
 );
 
-const arbeitsweise = z.object({
+const arbeitArt = z.object({
   angestellt: checkedOptional,
   selbstaendig: checkedOptional,
 });
@@ -85,7 +85,7 @@ export const context = {
   hasKontopfaendung,
   hasPKonto,
   schuldenBei,
-  euroSchwelle,
+  sockelbetrag,
   hasKinder: YesNoAnswer,
   kinderWohnenZusammen,
   verheiratet,
@@ -93,7 +93,7 @@ export const context = {
   partnerWohnenZusammen: YesNoAnswer,
   partnerUnterhalt: YesNoAnswer,
   hasArbeit: YesNoAnswer,
-  arbeitsweise,
+  arbeitArt,
   nachzahlungArbeitgeber: YesNoAnswer,
   arbeitgeberNachzahlungHigherThan: YesNoAnswer,
   zahlungArbeitgeber,
@@ -102,8 +102,8 @@ export const context = {
   hasSozialleistungNachzahlung: YesNoAnswer,
   sozialleistungNachzahlungHigherThan: YesNoAnswer,
   hasSozialleistungenEinmalzahlung: YesNoAnswer,
-  unerlaubteHandlung: YesNoAnswer,
-  unterhaltszahlungen: YesNoAnswer,
+  pfaendungStrafe: YesNoAnswer,
+  pfaendungUnterhalt: YesNoAnswer,
   pflegegeld,
 } as const;
 

--- a/app/domains/kontopfaendung/wegweiser/stringReplacements.ts
+++ b/app/domains/kontopfaendung/wegweiser/stringReplacements.ts
@@ -18,8 +18,8 @@ export const getPrivilegierteForderungStrings = (
   userData: KontopfaendungWegweiserContext,
 ) => {
   return {
-    isPrivilegierteForderungStrafe: userData.unerlaubteHandlung === "yes",
-    isPrivilegierteForderungUnterhalt: userData.unterhaltszahlungen === "yes",
+    isPrivilegierteForderungStrafe: userData.pfaendungStrafe === "yes",
+    isPrivilegierteForderungUnterhalt: userData.pfaendungUnterhalt === "yes",
   };
 };
 export const getErhoehungsbetragStrings = (
@@ -160,14 +160,14 @@ export const getSelbststaendigStrings = (
   userData: KontopfaendungWegweiserContext,
 ) => {
   return {
-    isSelbststaendig: userData.arbeitsweise?.selbstaendig === CheckboxValue.on,
+    isSelbststaendig: userData.arbeitArt?.selbstaendig === CheckboxValue.on,
   };
 };
 export const getAngestelltStrings = (
   userData: KontopfaendungWegweiserContext,
 ) => {
   return {
-    isAngestellt: userData.arbeitsweise?.angestellt === CheckboxValue.on,
+    isAngestellt: userData.arbeitArt?.angestellt === CheckboxValue.on,
   };
 };
 export const getKinderStrings = (userData: KontopfaendungWegweiserContext) => {

--- a/app/domains/kontopfaendung/wegweiser/xStateConfig.ts
+++ b/app/domains/kontopfaendung/wegweiser/xStateConfig.ts
@@ -63,18 +63,18 @@ export const kontopfaendungWegweiserXstateConfig = {
             guard: ({ context }) => context.schuldenBei === "weissNicht",
           },
           {
-            target: "unerlaubten-handlung",
+            target: "pfaendung-strafe",
             guard: ({ context }) =>
               context.schuldenBei === "staatsanwaltschaft" ||
               context.schuldenBei === "kasse",
           },
           {
-            target: "unterhalts-zahlungen",
+            target: "pfaendung-unterhalt",
             guard: ({ context }) =>
               context.schuldenBei === "privat" ||
               context.schuldenBei === "jugendamt",
           },
-          "euro-schwelle",
+          "sockelbetrag",
         ],
         BACK: [
           {
@@ -86,30 +86,30 @@ export const kontopfaendungWegweiserXstateConfig = {
         ],
       },
     },
-    "unerlaubten-handlung": {
+    "pfaendung-strafe": {
       on: {
-        SUBMIT: "euro-schwelle",
+        SUBMIT: "sockelbetrag",
         BACK: "glaeubiger",
       },
     },
-    "unterhalts-zahlungen": {
+    "pfaendung-unterhalt": {
       on: {
-        SUBMIT: "euro-schwelle",
+        SUBMIT: "sockelbetrag",
         BACK: "glaeubiger",
       },
     },
     "glaeubiger-unbekannt": {
       on: {
-        SUBMIT: "euro-schwelle",
+        SUBMIT: "sockelbetrag",
         BACK: "glaeubiger",
       },
     },
-    "euro-schwelle": {
+    sockelbetrag: {
       on: {
         SUBMIT: [
           {
             target: "ergebnis/geringe-einkuenfte",
-            guard: ({ context }) => context.euroSchwelle === "nein",
+            guard: ({ context }) => context.sockelbetrag === "nein",
           },
           "zwischenseite-unterhalt",
         ],
@@ -119,13 +119,13 @@ export const kontopfaendungWegweiserXstateConfig = {
             guard: ({ context }) => context.schuldenBei === "weissNicht",
           },
           {
-            target: "unerlaubten-handlung",
+            target: "pfaendung-strafe",
             guard: ({ context }) =>
               context.schuldenBei === "staatsanwaltschaft" ||
               context.schuldenBei === "kasse",
           },
           {
-            target: "unterhalts-zahlungen",
+            target: "pfaendung-unterhalt",
             guard: ({ context }) =>
               context.schuldenBei === "privat" ||
               context.schuldenBei === "jugendamt",
@@ -135,12 +135,12 @@ export const kontopfaendungWegweiserXstateConfig = {
       },
     },
     "ergebnis/geringe-einkuenfte": {
-      on: { BACK: "euro-schwelle" },
+      on: { BACK: "sockelbetrag" },
     },
     "zwischenseite-unterhalt": {
       on: {
         SUBMIT: "kinder",
-        BACK: "euro-schwelle",
+        BACK: "sockelbetrag",
       },
     },
     kinder: {
@@ -157,11 +157,11 @@ export const kontopfaendungWegweiserXstateConfig = {
     },
     "kinder-wohnen-zusammen": {
       on: {
-        SUBMIT: "kinder-support",
+        SUBMIT: "kinder-unterhalt",
         BACK: "kinder",
       },
     },
-    "kinder-support": {
+    "kinder-unterhalt": {
       on: {
         SUBMIT: "partner",
         BACK: "kinder-wohnen-zusammen",
@@ -171,7 +171,7 @@ export const kontopfaendungWegweiserXstateConfig = {
       on: {
         SUBMIT: [
           {
-            target: "partner-support",
+            target: "partner-unterhalt",
             guard: ({ context }) =>
               context.verheiratet === "getrennt" ||
               context.verheiratet === "geschieden" ||
@@ -182,11 +182,11 @@ export const kontopfaendungWegweiserXstateConfig = {
             guard: ({ context }) =>
               !!context.verheiratet && context.verheiratet !== "nein",
           },
-          "zwischenseite-cash",
+          "zwischenseite-einkuenfte",
         ],
         BACK: [
           {
-            target: "kinder-support",
+            target: "kinder-unterhalt",
             guard: ({ context }) => context.hasKinder === "yes",
           },
           "kinder",
@@ -195,13 +195,13 @@ export const kontopfaendungWegweiserXstateConfig = {
     },
     "partner-wohnen-zusammen": {
       on: {
-        SUBMIT: "partner-support",
+        SUBMIT: "partner-unterhalt",
         BACK: "partner",
       },
     },
-    "partner-support": {
+    "partner-unterhalt": {
       on: {
-        SUBMIT: "zwischenseite-cash",
+        SUBMIT: "zwischenseite-einkuenfte",
         BACK: [
           {
             target: "partner",
@@ -211,12 +211,12 @@ export const kontopfaendungWegweiserXstateConfig = {
         ],
       },
     },
-    "zwischenseite-cash": {
+    "zwischenseite-einkuenfte": {
       on: {
-        SUBMIT: "ermittlung-betrags",
+        SUBMIT: "arbeit",
         BACK: [
           {
-            target: "partner-support",
+            target: "partner-unterhalt",
             guard: ({ context }) =>
               !!context.verheiratet && context.verheiratet !== "nein",
           },
@@ -224,50 +224,48 @@ export const kontopfaendungWegweiserXstateConfig = {
         ],
       },
     },
-    // TODO rename
-    "ermittlung-betrags": {
+    arbeit: {
       on: {
         SUBMIT: [
           {
-            target: "arbeitsweise",
+            target: "arbeit-art",
             guard: ({ context }) => context.hasArbeit === "yes",
           },
           "sozialleistungen",
         ],
-        BACK: "zwischenseite-cash",
+        BACK: "zwischenseite-einkuenfte",
       },
     },
-    arbeitsweise: {
+    "arbeit-art": {
       on: {
         SUBMIT: "nachzahlung-arbeitgeber",
-        BACK: "ermittlung-betrags",
+        BACK: "arbeit",
       },
     },
     "nachzahlung-arbeitgeber": {
       on: {
         SUBMIT: [
           {
-            target: "zahlungslimit",
+            target: "hoehe-nachzahlung-arbeitgeber",
             guard: ({ context }) => context.nachzahlungArbeitgeber === "yes",
           },
-          // TODO Rename
-          "zahlung-arbeitgeber",
+          "einmalzahlung-arbeitgeber",
         ],
-        BACK: "arbeitsweise",
+        BACK: "arbeit-art",
       },
     },
-    zahlungslimit: {
+    "hoehe-nachzahlung-arbeitgeber": {
       on: {
-        SUBMIT: "zahlung-arbeitgeber",
+        SUBMIT: "einmalzahlung-arbeitgeber",
         BACK: "nachzahlung-arbeitgeber",
       },
     },
-    "zahlung-arbeitgeber": {
+    "einmalzahlung-arbeitgeber": {
       on: {
         SUBMIT: "sozialleistungen",
         BACK: [
           {
-            target: "zahlungslimit",
+            target: "hoehe-nachzahlung-arbeitgeber",
             guard: ({ context }) => context.nachzahlungArbeitgeber === "yes",
           },
           "nachzahlung-arbeitgeber",
@@ -283,10 +281,10 @@ export const kontopfaendungWegweiserXstateConfig = {
         ],
         BACK: [
           {
-            target: "zahlung-arbeitgeber",
+            target: "einmalzahlung-arbeitgeber",
             guard: ({ context }) => context.hasArbeit === "yes",
           },
-          "ermittlung-betrags",
+          "arbeit",
         ],
       },
     },
@@ -318,7 +316,7 @@ export const kontopfaendungWegweiserXstateConfig = {
       on: {
         SUBMIT: [
           {
-            target: "sozialleistung-nachzahlung-amount",
+            target: "hoehe-nachzahlung-sozialleistung",
             guard: ({ context }) =>
               context.hasSozialleistungNachzahlung === "yes",
           },
@@ -340,7 +338,7 @@ export const kontopfaendungWegweiserXstateConfig = {
         ],
       },
     },
-    "sozialleistung-nachzahlung-amount": {
+    "hoehe-nachzahlung-sozialleistung": {
       on: {
         SUBMIT: "sozialleistungen-einmalzahlung",
         BACK: "sozialleistung-nachzahlung",
@@ -351,7 +349,7 @@ export const kontopfaendungWegweiserXstateConfig = {
         SUBMIT: "ergebnis/naechste-schritte",
         BACK: [
           {
-            target: "sozialleistung-nachzahlung-amount",
+            target: "hoehe-nachzahlung-sozialleistung",
             guard: ({ context }) =>
               context.hasSozialleistungNachzahlung === "yes",
           },


### PR DESCRIPTION
This PR renames the page flows for Wegweiser as follows. Context and tescases were updated as well.

euro-schwelle -> sockelbetrag
kinder-support -> kinder-unterhalt
partner-support -> partner-unterhalt
zwischenseite-cash -> zwischenseite-einkuenfte
ermittlung-betrags -> arbeit
arbeitsweise -> arbeit-art
zahlungslimit -> hoehe-nachzahlung-arbeitgeber
zahlung-arbeitgeber -> einmalzahlung-arbeitgeber
sozialleistung-nachzahlung-amount -> hoehe-nachzahlung-sozialleistung
unterhalts-zahlungen -> pfaendung-unterhalt
unerlaubten-handlung -> pfaendung-strafe 