### PR TITLE
fix(Wegweiser): remove nichts trifft zu option from sozialleistungenUmstaende

### DIFF
--- a/app/domains/kontopfaendung/wegweiser/__test__/stringReplacements.test.ts
+++ b/app/domains/kontopfaendung/wegweiser/__test__/stringReplacements.test.ts
@@ -72,7 +72,6 @@ describe("stringReplacements", () => {
       const userData: KontopfaendungWegweiserContext = {
         sozialleistungenUmstaende: {
           kindergeld: CheckboxValue.on,
-          nein: CheckboxValue.off,
           pflegegeld: CheckboxValue.off,
           wohngeld: CheckboxValue.off,
         },
@@ -87,7 +86,6 @@ describe("stringReplacements", () => {
       const userData: KontopfaendungWegweiserContext = {
         sozialleistungenUmstaende: {
           wohngeld: CheckboxValue.on,
-          nein: CheckboxValue.off,
           pflegegeld: CheckboxValue.off,
           kindergeld: CheckboxValue.off,
         },

--- a/app/domains/kontopfaendung/wegweiser/__test__/testcases.ts
+++ b/app/domains/kontopfaendung/wegweiser/__test__/testcases.ts
@@ -131,7 +131,6 @@ const cases = [
         pflegegeld: CheckboxValue.on,
         kindergeld: CheckboxValue.off,
         wohngeld: CheckboxValue.off,
-        nein: CheckboxValue.off,
       },
     },
     [
@@ -150,7 +149,6 @@ const cases = [
         pflegegeld: CheckboxValue.off,
         kindergeld: CheckboxValue.off,
         wohngeld: CheckboxValue.off,
-        nein: CheckboxValue.off,
       },
     },
     [
@@ -166,25 +164,6 @@ const cases = [
         pflegegeld: CheckboxValue.off,
         kindergeld: CheckboxValue.on,
         wohngeld: CheckboxValue.on,
-        nein: CheckboxValue.off,
-      },
-    },
-    [
-      "/sozialleistungen",
-      "/sozialleistungen-umstaende",
-      "/sozialleistung-nachzahlung",
-      "/sozialleistungen-einmalzahlung",
-      "/ergebnis/naechste-schritte",
-    ],
-  ],
-  [
-    {
-      hasSozialleistungen: "nein",
-      sozialleistungenUmstaende: {
-        pflegegeld: CheckboxValue.off,
-        kindergeld: CheckboxValue.on,
-        wohngeld: CheckboxValue.on,
-        nein: CheckboxValue.off,
       },
     },
     [
@@ -202,7 +181,23 @@ const cases = [
         pflegegeld: CheckboxValue.off,
         kindergeld: CheckboxValue.on,
         wohngeld: CheckboxValue.on,
-        nein: CheckboxValue.off,
+      },
+    },
+    [
+      "/sozialleistungen",
+      "/sozialleistungen-umstaende",
+      "/sozialleistung-nachzahlung",
+      "/sozialleistungen-einmalzahlung",
+      "/ergebnis/naechste-schritte",
+    ],
+  ],
+  [
+    {
+      hasSozialleistungen: "nein",
+      sozialleistungenUmstaende: {
+        pflegegeld: CheckboxValue.off,
+        kindergeld: CheckboxValue.on,
+        wohngeld: CheckboxValue.on,
       },
       hasSozialleistungNachzahlung: "no",
     },
@@ -219,7 +214,6 @@ const cases = [
         pflegegeld: CheckboxValue.off,
         kindergeld: CheckboxValue.on,
         wohngeld: CheckboxValue.on,
-        nein: CheckboxValue.off,
       },
       hasSozialleistungNachzahlung: "yes",
     },
@@ -244,7 +238,6 @@ const cases = [
       nachzahlungArbeitgeber: "yes",
       hasSozialleistungen: "nein",
       sozialleistungenUmstaende: {
-        nein: CheckboxValue.off,
         kindergeld: CheckboxValue.on,
         pflegegeld: CheckboxValue.off,
         wohngeld: CheckboxValue.off,

--- a/app/domains/kontopfaendung/wegweiser/context.ts
+++ b/app/domains/kontopfaendung/wegweiser/context.ts
@@ -76,7 +76,6 @@ const sozialleistungenUmstaende = z.object({
   pflegegeld: checkedOptional,
   kindergeld: checkedOptional,
   wohngeld: checkedOptional,
-  nein: checkedOptional,
 });
 
 const pflegegeld = z.enum(["selbst", "fremd"], customRequiredErrorMessage);


### PR DESCRIPTION
This PR removes the checkbox option "nichts trifft zu" from sozialleistungenUmstaende