### PR TITLE
add to sentry ignore errors: Detected manifest version mismatch, relo…

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -5,7 +5,11 @@ import { HydratedRouter } from "react-router/dom";
 import { config } from "~/services/env/web";
 
 // Ignore a few common errors that are not useful to track
-const SENTRY_IGNORE_ERRORS = ["Error in input stream", "Load failed"];
+const SENTRY_IGNORE_ERRORS = [
+  "Error in input stream",
+  "Load failed",
+  "Detected manifest version mismatch, reloading...",
+];
 
 const { SENTRY_DSN, ENVIRONMENT } = config();
 if (SENTRY_DSN !== undefined) {


### PR DESCRIPTION
as alex discovered that this seems to be a [known issue](https://github.com/remix-run/react-router/issues/13332) in the current react router version we decided to put the error on the ignore list for now 