### PR TITLE
Proposal: move translation into component

### DIFF
--- a/app/components/userFeedback/RatingBox.tsx
+++ b/app/components/userFeedback/RatingBox.tsx
@@ -2,7 +2,6 @@ import ThumbDownIcon from "@digitalservicebund/icons/ThumbDownOutlined";
 import ThumbUpIcon from "@digitalservicebund/icons/ThumbUpOutlined";
 import { useFetcher } from "react-router";
 import { useJsAvailable } from "~/services/useJsAvailable";
-import { useFeedbackTranslations } from "./feedbackTranslations";
 import { FeedbackType } from "./FeedbackType";
 import Button from "../Button";
 import ButtonContainer from "../ButtonContainer";
@@ -19,7 +18,6 @@ export type RatingBoxProps = {
 export const RatingBox = ({ heading, url, onSubmit }: RatingBoxProps) => {
   const ratingFetcher = useFetcher();
   const jsAvailable = useJsAvailable();
-  const feedbackTranslations = useFeedbackTranslations();
   return (
     <>
       <Heading look="ds-label-01-bold" tagName="h2" text={heading} />
@@ -38,9 +36,9 @@ export const RatingBox = ({ heading, url, onSubmit }: RatingBoxProps) => {
             onClick={() => {
               onSubmit(FeedbackType.Positive);
             }}
-            aria-label={`${heading}, ${feedbackTranslations["yes-rating"]}`}
+            aria-label={`${heading}, Ja`}
           >
-            {feedbackTranslations["yes-rating"]}
+            Ja
           </Button>
           <Button
             iconLeft={<ThumbDownIcon />}
@@ -51,9 +49,9 @@ export const RatingBox = ({ heading, url, onSubmit }: RatingBoxProps) => {
             onClick={() => {
               onSubmit(FeedbackType.Negative);
             }}
-            aria-label={`${heading}, ${feedbackTranslations["no-rating"]}`}
+            aria-label={`${heading}, Nein`}
           >
-            {feedbackTranslations["no-rating"]}
+            Nein
           </Button>
         </ButtonContainer>
       </ratingFetcher.Form>

--- a/app/components/userFeedback/__test__/RatingBox.test.tsx
+++ b/app/components/userFeedback/__test__/RatingBox.test.tsx
@@ -1,41 +1,16 @@
 import { fireEvent, render } from "@testing-library/react";
 import { createRoutesStub } from "react-router";
+import { FeedbackType } from "../FeedbackType";
 import { RatingBox } from "../RatingBox";
 
-const YES_RATING = "yes";
-const NO_RATING = "no";
-
-vi.mock("~/components/userFeedback/feedbackTranslations", () => ({
-  useFeedbackTranslations: () => ({
-    ["yes-rating"]: YES_RATING,
-    ["no-rating"]: NO_RATING,
-  }),
-}));
-
 describe("RatingBox", () => {
-  it("should render the component with the given translations", () => {
-    const RatingBoxWithRouteStub = createRoutesStub([
-      {
-        path: "",
-        Component: () => (
-          <RatingBox heading="heading" url="url" onSubmit={vitest.fn()} />
-        ),
-      },
-    ]);
-    const { getByText } = render(<RatingBoxWithRouteStub />);
-
-    expect(getByText(YES_RATING)).toBeInTheDocument();
-    expect(getByText(NO_RATING)).toBeInTheDocument();
-  });
-
-  it("should call onSubmit method when clicks on the Yes button", () => {
+  it("should call onSubmit method when any button is clicked", () => {
     const onSubmitMock = vitest.fn();
-
     const RatingBoxWithRouteStub = createRoutesStub([
       {
-        path: "",
+        path: "/",
         Component: () => (
-          <RatingBox heading="heading" url="url" onSubmit={onSubmitMock} />
+          <RatingBox heading="heading" url="/url" onSubmit={onSubmitMock} />
         ),
       },
       {
@@ -46,32 +21,9 @@ describe("RatingBox", () => {
       },
     ]);
     const { getByText } = render(<RatingBoxWithRouteStub />);
-    fireEvent.click(getByText(YES_RATING));
-
-    expect(onSubmitMock).toBeCalled();
-  });
-
-  it("should call obSubmit method when clicks on the No button", () => {
-    const onSubmitMock = vitest.fn();
-
-    const RatingBoxWithRouteStub = createRoutesStub([
-      {
-        path: "",
-        Component: () => (
-          <RatingBox heading="heading" url="url" onSubmit={onSubmitMock} />
-        ),
-      },
-      {
-        path: "/action/send-rating",
-        action() {
-          return {};
-        },
-      },
-    ]);
-    const { getByText } = render(<RatingBoxWithRouteStub />);
-
-    fireEvent.click(getByText(NO_RATING));
-
-    expect(onSubmitMock).toBeCalled();
+    fireEvent.click(getByText("Ja"));
+    expect(onSubmitMock).toBeCalledWith(FeedbackType.Positive);
+    fireEvent.click(getByText("Nein"));
+    expect(onSubmitMock).toBeCalledWith(FeedbackType.Negative);
   });
 });

--- a/app/components/userFeedback/feedbackTranslations.ts
+++ b/app/components/userFeedback/feedbackTranslations.ts
@@ -27,22 +27,12 @@ const postSubmissionTranslationKeys = [
 type PostSubmissionTranslationKeys =
   (typeof postSubmissionTranslationKeys)[number];
 
-const ratingBoxTranslationsKeys = ["yes-rating", "no-rating"] as const;
-type RatingBoxTranslationKeys = (typeof ratingBoxTranslationsKeys)[number];
-
 export function useFeedbackTranslations() {
   const { feedback: translations } = useTranslations();
 
   return Object.fromEntries(
-    [
-      ...feedbackTranslationsKeys,
-      ...postSubmissionTranslationKeys,
-      ...ratingBoxTranslationsKeys,
-    ].map((key) => [key, getTranslationByKey(key, translations)]),
-  ) as Record<
-    | FeedbackTranslationKeys
-    | PostSubmissionTranslationKeys
-    | RatingBoxTranslationKeys,
-    string
-  >;
+    [...feedbackTranslationsKeys, ...postSubmissionTranslationKeys].map(
+      (key) => [key, getTranslationByKey(key, translations)],
+    ),
+  ) as Record<FeedbackTranslationKeys | PostSubmissionTranslationKeys, string>;
 }


### PR DESCRIPTION
Following discussion on reducing the amount of strings from the CMS:

Removing the string lookup for `Ja` and `Nein` simplifies component, tests and scaffolding around it..  