### PR TITLE
bug(PKH): allow PDF generation with special characters 

### DIFF
--- a/app/domains/prozesskostenhilfe/services/pdf/__test__/printNameInSignatureFormField.test.ts
+++ b/app/domains/prozesskostenhilfe/services/pdf/__test__/printNameInSignatureFormField.test.ts
@@ -1,7 +1,11 @@
+import fs from "fs";
+import fontkit from "@pdf-lib/fontkit";
 import type { PDFDocument } from "pdf-lib";
 import type { ProzesskostenhilfeFormularContext } from "~/domains/prozesskostenhilfe/formular/context";
 import { printNameInSignatureFormField } from "../printNameInSignatureFormField";
 
+vi.mock("fs");
+vi.mock("@pdf-lib/fontkit");
 vi.mock("pdf-lib", async () => {
   const original = await vi.importActual("pdf-lib");
   return {
@@ -16,22 +20,22 @@ const mockPdfDoc = {
   getPage: vi.fn().mockReturnValue({
     drawText: vi.fn(),
   }),
+  registerFontkit: vi.fn(),
+  embedFont: vi.fn(),
 } as unknown as PDFDocument;
-
-const userData: ProzesskostenhilfeFormularContext = {
-  vorname: "Rosa",
-  nachname: "Ritter",
-  versandArt: "digital",
-};
 
 describe("printNameInSignatureFormField", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should call drawText with correct arguments when versandArt is "digital"', () => {
-    printNameInSignatureFormField(mockPdfDoc, userData);
-
+  it('should call drawText with correct arguments when versandArt is "digital"', async () => {
+    const userData: ProzesskostenhilfeFormularContext = {
+      vorname: "Rosa",
+      nachname: "Ritter",
+      versandArt: "digital",
+    };
+    await printNameInSignatureFormField(mockPdfDoc, userData);
     expect(mockPdfDoc.getPage(3).drawText).toHaveBeenCalledWith("Rosa Ritter", {
       x: 200,
       y: 75,
@@ -39,14 +43,43 @@ describe("printNameInSignatureFormField", () => {
     });
   });
 
-  it('should not call drawText when versandArt is "analog"', () => {
+  it('should not call drawText when versandArt is "analog"', async () => {
     const userDataAnalog: ProzesskostenhilfeFormularContext = {
-      ...userData,
+      vorname: "Rosa",
+      nachname: "Ritter",
       versandArt: "analog",
     };
-
-    printNameInSignatureFormField(mockPdfDoc, userDataAnalog);
-
+    await printNameInSignatureFormField(mockPdfDoc, userDataAnalog);
     expect(mockPdfDoc.getPage(3).drawText).not.toHaveBeenCalled();
+  });
+
+  it("should handle correctly special characters", async () => {
+    const userData: ProzesskostenhilfeFormularContext = {
+      vorname: "Włodzimierz",
+      nachname: "Ćwikłań",
+      versandArt: "digital",
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from("mock font data"));
+
+    await printNameInSignatureFormField(mockPdfDoc, userData);
+
+    expect(mockPdfDoc.registerFontkit).toHaveBeenCalledWith(fontkit);
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      "public/fonts/BundesSansWeb-Regular.woff",
+    );
+    expect(mockPdfDoc.embedFont).toHaveBeenCalledWith(
+      Buffer.from("mock font data"),
+      { subset: true },
+    );
+
+    expect(mockPdfDoc.getPage(3).drawText).toHaveBeenCalledWith(
+      "Włodzimierz Ćwikłań",
+      {
+        x: 200,
+        y: 75,
+        size: 10,
+      },
+    );
   });
 });

--- a/app/domains/prozesskostenhilfe/services/pdf/index.ts
+++ b/app/domains/prozesskostenhilfe/services/pdf/index.ts
@@ -99,7 +99,7 @@ export async function prozesskostenhilfePdfFromUserdata(
     xPositionsDruckvermerk: 9,
   });
 
-  printNameInSignatureFormField(filledPdfFormDocument, userData);
+  await printNameInSignatureFormField(filledPdfFormDocument, userData);
 
   const filledPdfFormDocumentWithMetadata = addMetadataToPdf(
     filledPdfFormDocument,

--- a/app/domains/prozesskostenhilfe/services/pdf/printNameInSignatureFormField.ts
+++ b/app/domains/prozesskostenhilfe/services/pdf/printNameInSignatureFormField.ts
@@ -1,15 +1,26 @@
+import fs from "fs";
+import fontkit from "@pdf-lib/fontkit";
 import type { PDFDocument } from "pdf-lib";
 import type { ProzesskostenhilfeFormularContext } from "../../formular/context";
 
-export function printNameInSignatureFormField(
+export async function printNameInSignatureFormField(
   pdfDoc: PDFDocument,
   userData: ProzesskostenhilfeFormularContext,
 ) {
   if (userData.versandArt === "digital") {
+    // registering fontkit with PDFDocument to encode and embed Unicode characters like "ń", "ś", "ł"
+    // without fontkit, pdf-lib will use simple encoding (WinAnsi) and will throw "WinAnsi cannot encode
+    // "ń" when it does not know how to encode
+    pdfDoc.registerFontkit(fontkit);
+    const fontBytes = fs.readFileSync(
+      "public/fonts/BundesSansWeb-Regular.woff",
+    );
+    const font = await pdfDoc.embedFont(fontBytes, { subset: true });
     pdfDoc.getPage(3).drawText(`${userData.vorname} ${userData.nachname}`, {
       x: 200,
       y: 75,
       size: 10,
+      font: font,
     });
   }
 }


### PR DESCRIPTION
This PR fixes the PDF generation with special characters:
- Register fontkit with PDFDocument in the printNameInSignatureFormField to allow pdf to be generated with special characters like "ń"