### PR TITLE
fix(Strapi List HTML Bug)

### DIFF
--- a/app/services/security/__test__/markdownUtilities.test.ts
+++ b/app/services/security/__test__/markdownUtilities.test.ts
@@ -71,14 +71,14 @@ describe("markdownUtilities", () => {
       expect(handleNestedLists(html)).toBe(html);
     });
 
-    it("should reorder the opening and closing list tags if needed", () => {
+    it("should reorder an opening list tag if needed", () => {
       const htmlNestedList =
-        "{{ #conditional }}<ul><li>item 1</li></ul>{{ /conditional }}";
+        "{{ #conditional }}<ul><li>item 1</li>{{ /conditional }}</ul>";
       const expectedHtml =
         "<ul>{{ #conditional }}<li>item 1</li>{{ /conditional }}</ul>";
       expect(handleNestedLists(htmlNestedList)).toBe(expectedHtml);
       const invertedConditionHtml =
-        "{{^conditional}}<ul><li>item 1</li></ul>{{/conditional}}";
+        "{{^conditional}}<ul><li>item 1</li>{{/conditional}}</ul>";
       const expectedInvertedConditionHtml =
         "<ul>{{^conditional}}<li>item 1</li>{{/conditional}}</ul>";
       expect(handleNestedLists(invertedConditionHtml)).toBe(
@@ -86,18 +86,18 @@ describe("markdownUtilities", () => {
       );
     });
 
-    it("should only retain one set of opening and closing list tags", () => {
+    it("should handle multiple lists", () => {
       const htmlNestedUnorderedList =
-        "{{ #conditional }}<ul><li>item 1</li></ul><ul><li>item 2</li></ul>{{ /conditional }}";
+        "{{ #conditional }}<ul><li>item 1</li>{{ /conditional }}</ul>{{ #conditional2 }}<ul><li>item 2</li>{{ /conditional2 }}</ul>";
       const expectedHtmlUnorderedList =
-        "<ul>{{ #conditional }}<li>item 1</li><li>item 2</li>{{ /conditional }}</ul>";
+        "<ul>{{ #conditional }}<li>item 1</li>{{ /conditional }}</ul><ul>{{ #conditional2 }}<li>item 2</li>{{ /conditional2 }}</ul>";
       expect(handleNestedLists(htmlNestedUnorderedList)).toBe(
         expectedHtmlUnorderedList,
       );
       const htmlNestedOrderedList =
-        "{{ #conditional }}<ol><li>item 1</li></ol><ol><li>item 2</li></ol>{{ /conditional }}";
+        "{{ #conditional }}<ol><li>item 1</li>{{ /conditional }}</ol>{{ #conditional2 }}<ol><li>item 2</li>{{ /conditional2 }}</ol>";
       const expectedHtmlOrderedList =
-        "<ol>{{ #conditional }}<li>item 1</li><li>item 2</li>{{ /conditional }}</ol>";
+        "<ol>{{ #conditional }}<li>item 1</li>{{ /conditional }}</ol><ol>{{ #conditional2 }}<li>item 2</li>{{ /conditional2 }}</ol>";
       expect(handleNestedLists(htmlNestedOrderedList)).toBe(
         expectedHtmlOrderedList,
       );

--- a/app/services/security/markdownUtilities.tsx
+++ b/app/services/security/markdownUtilities.tsx
@@ -91,7 +91,9 @@ export function parseAndSanitizeMarkdown(
  * This function iteratively walks through the input html, swapping the order of opening list tags and opening conditionals.
  */
 export function handleNestedLists(html: string) {
-  const nestedLists = [...html.matchAll(/{{\s*#\w+\s*}}(?=.*\n*(<ul>|<ol>))/g)];
+  const nestedLists = [
+    ...html.matchAll(/{{\s*[#|^]\w+\s*}}(?=.*\n*(<ul>|<ol>))/g),
+  ];
   if (nestedLists.length > 0 && !contentExistsBeforeList(html)) {
     let fixedMarkup = html;
     for (const nestedList of nestedLists) {


### PR DESCRIPTION
Well that was annoying.

Fix handleNestedLists postfixer to correctly un-nest opening list tags outside of mustache conditionals to ensure accessibility-compliant, syntactically-correct html

- **vastly simplify nested list logic**
- **adapt unit test, adapt function to handle inverted condtions too**
