### PR TITLE
feat(PKH AB Test): add component to display AB test version

### DIFF
--- a/app/components/AbTest/EstimatedTimeAbTest.tsx
+++ b/app/components/AbTest/EstimatedTimeAbTest.tsx
@@ -1,0 +1,38 @@
+import TimerOutlinedIcon from "@digitalservicebund/icons/TimerOutlined";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
+import { useLocation } from "react-router";
+
+export function EstimatedTimeAbTest() {
+  /**
+   * Hook to determine whether to display the estimated time string and icon.
+   *
+   * The hook uses the PostHog useFeatureFlagVariantKey hook to determine whether the
+   * user is in the test or control group of the "conversion-rate-pkh-flow" feature flag.
+   *
+   * If the user is on the start page of the PKH flow and is in the test group, the hook
+   * returns true. Otherwise, it returns false.
+   *
+   * @returns {boolean} Whether to display the estimated time string and icon.
+   */
+  function useDisplayEstimatedTimeAbTest(): boolean {
+    const { pathname } = useLocation();
+    const variantKey = useFeatureFlagVariantKey("conversion-rate-pkh-flow");
+    const isOnPKHFlowStartPage = pathname.includes(
+      "prozesskostenhilfe/formular/start/start",
+    );
+    const isTestGroup = variantKey === "test";
+
+    return isOnPKHFlowStartPage && isTestGroup;
+  }
+
+  return (
+    <>
+      {useDisplayEstimatedTimeAbTest() && (
+        <span className="flex items-center ds-body-02-reg text-gray-900">
+          <TimerOutlinedIcon className="shrink-0 fill-gray-900 mr-4" />
+          {"Geschätzte Zeit: 20 Minuten"}
+        </span>
+      )}
+    </>
+  );
+}

--- a/app/components/AbTest/__test__/EstimatedTimeAbTest.test.tsx
+++ b/app/components/AbTest/__test__/EstimatedTimeAbTest.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
+import { useLocation } from "react-router";
+import { vi, type Mock } from "vitest";
+import { EstimatedTimeAbTest } from "../EstimatedTimeAbTest";
+
+vi.mock("posthog-js/react", () => {
+  return {
+    useFeatureFlagVariantKey: vi.fn(),
+  };
+});
+vi.mock("react-router", () => {
+  return {
+    useLocation: vi.fn(),
+  };
+});
+
+const useFeatureFlagVariantKeyMock = useFeatureFlagVariantKey as Mock;
+const useLocationMock = useLocation as Mock;
+
+describe("EstimatedTimeAbTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render estimated time when on PKH flow start page and in test group", () => {
+    useFeatureFlagVariantKeyMock.mockReturnValue("test");
+    useLocationMock.mockReturnValue({
+      pathname: "/prozesskostenhilfe/formular/start/start",
+    });
+    render(<EstimatedTimeAbTest />);
+    expect(screen.getByText("Geschätzte Zeit: 20 Minuten")).toBeInTheDocument();
+    expect(screen.getByTestId("TimerOutlinedIcon")).toBeInTheDocument();
+  });
+
+  it("should not render estimated time when not on PKH flow start page", () => {
+    useFeatureFlagVariantKeyMock.mockReturnValue("test");
+    useLocationMock.mockReturnValue({
+      pathname: "/prozesskostenhilfe/formular/other",
+    });
+    expect(
+      screen.queryByText("Geschätzte Zeit: 20 Minuten"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("TimerOutlinedIcon")).not.toBeInTheDocument();
+  });
+
+  it("should not render estimated time when in control group", () => {
+    useFeatureFlagVariantKeyMock.mockReturnValue("control");
+    useLocationMock.mockReturnValue({
+      pathname: "/prozesskostenhilfe/formular/start/start",
+    });
+    expect(
+      screen.queryByText("Geschätzte Zeit: 20 Minuten"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("TimerOutlinedIcon")).not.toBeInTheDocument();
+  });
+
+  it("should not render estimated time when variantKey is undefined", () => {
+    useFeatureFlagVariantKeyMock.mockReturnValue(undefined);
+    useLocationMock.mockReturnValue({
+      pathname: "/prozesskostenhilfe/formular/start/start",
+    });
+    expect(
+      screen.queryByText("Geschätzte Zeit: 20 Minuten"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("TimerOutlinedIcon")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/form/ValidatedFlowForm.tsx
+++ b/app/components/form/ValidatedFlowForm.tsx
@@ -7,6 +7,7 @@ import { StrapiFormComponents } from "~/services/cms/components/StrapiFormCompon
 import type { StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
 import { CSRFKey } from "~/services/security/csrf/csrfKey";
 import { schemaForFieldNames } from "~/services/validation/stepValidator/schemaForFieldNames";
+import { EstimatedTimeAbTest } from "../AbTest/EstimatedTimeAbTest";
 
 type ValidatedFlowFormProps = {
   stepData: Context;
@@ -37,6 +38,8 @@ function ValidatedFlowForm({
       <input type="hidden" name={CSRFKey} value={csrf} />
       <div className="ds-stack ds-stack-40">
         <StrapiFormComponents components={formElements} />
+        {/*THIS IS A TEMPORARY SOLUTION FOR THE AB TEST IN PROZESSKOSTENHILFE*/}
+        <EstimatedTimeAbTest />
         <ButtonNavigation {...buttonNavigationProps} />
       </div>
     </ValidatedForm>


### PR DESCRIPTION
This PR implements an icon and a string to the form when the flow is prozesskostenhilfe/formular and the feature flag conversion-rate-pkh-flow has the variant key test. When the feature flag has the variant key control the flow should be as before.
Using the multiple variant feature flag key helps us to check which experiment variant the user has been assigned to. In case of a problem with the experiment or feature flag, users will keep seeing the usual flow.