### PR TITLE
refactor(ci): parallel sonarcloud-scan job

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -16,8 +16,20 @@ env:
 jobs:
   code-quality:
     uses: ./.github/workflows/npm-checks.yml
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  sonarcloud-scan:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    needs: [code-quality]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        name: coverage
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf # v5.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   get-content-file:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -1,4 +1,6 @@
 name: NPMChecks
+on:
+  workflow_call:
 
 jobs:
   code-quality:

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -1,9 +1,4 @@
 name: NPMChecks
-on:
-  workflow_call:
-    secrets:
-      SONAR_TOKEN:
-        required: true
 
 jobs:
   code-quality:
@@ -20,8 +15,9 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/cached-checkout-install
       - run: npm run ${{ matrix.npmCMD }}
-      - name: SonarCloud Scan
-        if: ${{ github.actor != 'dependabot[bot]' && matrix.npmCMD == 'test:coverage' }}
-        uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf # v5.2.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Upload coverage
+        if: ${{ matrix.npmCMD == 'test:coverage' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           name: coverage
           path: coverage/
+          retention-days: 1

--- a/app/services/validation/stepValidator/__test__/schemaForFieldNames.test.ts
+++ b/app/services/validation/stepValidator/__test__/schemaForFieldNames.test.ts
@@ -1,0 +1,7 @@
+import { schemaForFieldNames } from "../schemaForFieldNames";
+
+describe("schemaForFieldNames", () => {
+  test("should throw for pathnames without flowId", () => {
+    expect(() => schemaForFieldNames([], "/not/a/flowId")).toThrow();
+  });
+});

--- a/app/services/validation/stepValidator/__test__/schemaForFieldNames.test.ts
+++ b/app/services/validation/stepValidator/__test__/schemaForFieldNames.test.ts
@@ -1,7 +1,0 @@
-import { schemaForFieldNames } from "../schemaForFieldNames";
-
-describe("schemaForFieldNames", () => {
-  test("should throw for pathnames without flowId", () => {
-    expect(() => schemaForFieldNames([], "/not/a/flowId")).toThrow();
-  });
-});


### PR DESCRIPTION
## before
<img width="351" alt="image" src="https://github.com/user-attachments/assets/ac1975c8-ab0b-47a6-802f-371a47d79ef4" />

test w coverage with included sonarcube blocks the pipeline for ~4 minutes


## after
<img width="755" alt="image" src="https://github.com/user-attachments/assets/0a4d99fe-796b-4a22-9906-052896f9f5ce" />

test with coverage takes about ~2 min, sonarcube runs by itself without blocking further deployment

