### PR TITLE
Make SVG icon of Tile component decorative

### DIFF
--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -3,6 +3,7 @@ import { useJsAvailable } from "~/services/useJsAvailable";
 
 export type ImageProps = Readonly<{
   url: string;
+  svgAriaHidden?: boolean;
   width?: number;
   height?: number;
   alternativeText?: string;
@@ -12,7 +13,7 @@ export type ImageProps = Readonly<{
 // Create a constant variable to avoid complains from Sonar
 const SVG_ROLE = "img";
 
-function Image({ url, alternativeText, ...props }: ImageProps) {
+function Image({ url, svgAriaHidden, alternativeText, ...props }: ImageProps) {
   const jsAvailable = useJsAvailable();
 
   const isSvg = url.endsWith(".svg");
@@ -43,6 +44,7 @@ function Image({ url, alternativeText, ...props }: ImageProps) {
       src={url}
       title={altText}
       role={SVG_ROLE}
+      aria-hidden={svgAriaHidden}
       height="100%"
     />
   );

--- a/app/components/inputs/tile/TileRadio.tsx
+++ b/app/components/inputs/tile/TileRadio.tsx
@@ -85,6 +85,7 @@ function TileRadio({
                 {...image}
                 width={IMAGE_WIDTH}
                 height={IMAGE_HEIGHT}
+                svgAriaHidden={true}
               />
             )}
             <TileTag tagDescription={tagDescription} />


### PR DESCRIPTION
Ticket: https://digitalservicebund.atlassian.net/browse/ZOV-221

### Changes

- Add props `svgAriaHidden` to render svg images with aria-hidden as false. 
- Make tile component render svg images with aria-hidden as true. It makes the icon as decorative according this [article](https://css-tricks.com/accessible-svgs/#aa-example-2-standalone-icon-decorative)

### Disclaimer

- It was not possible to add test because it's used an external component `react-inlinesvg`, where it fetches the url of the svg to render the component.