### PR TITLE
[Refactor] FileInput refactor and bug fix

### DIFF
--- a/app/components/filesUpload/FileUploadInfo.tsx
+++ b/app/components/filesUpload/FileUploadInfo.tsx
@@ -32,12 +32,10 @@ export const FileUploadInfo = ({
 
   return (
     <div className={classes} data-testid={`file-upload-info-${inputName}`}>
-      <div className="max-w-full flex justify-between items-center">
+      <div className="max-w-full grid grid-cols-[24px_1fr_auto] gap-x-12 items-center">
         <InsertFileIcon className="shrink-0 fill-gray-900" aria-hidden="true" />
-        <p className="ds-body-01-reg text-black mr-8 ml-10 truncate">
-          {file.filename}
-        </p>
-        <p className="ds-body-01-reg text-gray-900">
+        <p className="ds-body-01-reg text-black truncate">{file.filename}</p>
+        <p className="ds-body-01-reg text-gray-900 text-16">
           {formatFileSizeToString(file.fileSize)}
         </p>
       </div>

--- a/app/components/filesUpload/__test__/FileUploadInfo.test.tsx
+++ b/app/components/filesUpload/__test__/FileUploadInfo.test.tsx
@@ -26,9 +26,7 @@ describe("FileUploadInfo", () => {
     const fileNameLabel = getByText("testfile1.pdf");
     const fileIcon = getByTestId("InsertDriveFileIcon");
     expect(fileNameLabel).toBeInTheDocument();
-    expect(fileNameLabel).toHaveClass(
-      "ds-body-01-reg text-black mr-8 ml-10 truncate",
-    );
+    expect(fileNameLabel).toHaveClass("ds-body-01-reg text-black truncate");
     expect(fileIcon).toBeInTheDocument();
     expect(fileIcon).toHaveClass("shrink-0 fill-gray-900");
     expect(getByText(deleteButtonLabel)).toBeInTheDocument();

--- a/app/components/inputs/FileInput.tsx
+++ b/app/components/inputs/FileInput.tsx
@@ -29,33 +29,31 @@ export const FileInput = ({
   const errorId = `${name}-error`;
 
   const inputClasses = classNames(
-    "body-01-reg m-8 ml-0 file:ds-button file:ds-button-tertiary file:ds-button-large w-fit",
-    {
-      "w-0.1 h-0.1 opacity-0 overflow-hidden absolute z-0 cursor-pointer":
-        jsAvailable,
-    },
+    jsAvailable
+      ? "hidden"
+      : "body-01-reg m-8 ml-0 file:ds-button file:ds-button-tertiary file:ds-button-large w-fit file:cursor-pointer",
   );
 
   const FileInput = (
     <input
-      name={jsAvailable ? undefined : name}
-      onChange={(event) => {
-        const file = event.target.files?.[0];
-        void onFileUpload(name, file);
-      }}
+      id={name}
+      name={name}
       type="file"
       accept=".pdf"
       data-testid={`file-upload-input-${name}`}
       aria-invalid={error !== undefined}
       aria-errormessage={error && errorId}
       className={inputClasses}
-      {...(selectedFile ? { value: selectedFile.filename } : {})}
+      onChange={(event) => {
+        const file = event.target.files?.[0];
+        void onFileUpload(name, file);
+      }}
     />
   );
 
-  return (
-    <div className="flex-col">
-      {selectedFile ? (
+  if (selectedFile) {
+    return (
+      <>
         <FileUploadInfo
           inputName={name}
           onFileDelete={(fileName) => {
@@ -71,37 +69,46 @@ export const FileInput = ({
           deleteButtonLabel={translations.fileUpload.delete.de}
           hasError={!!error}
         />
+        {error && (
+          <InputError id={errorId}>
+            {errorMessages?.find((err) => err.code === error)?.text ?? error}
+          </InputError>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {jsAvailable ? (
+        <>
+          {FileInput}
+          <label
+            htmlFor={name}
+            className="relative inline-flex items-center ds-button ds-button-tertiary ds-button-large cursor-pointer w-fit"
+          >
+            <span className="ds-button-label">
+              {splitFieldName(name).inputIndex === 0
+                ? translations.fileUpload.select.de
+                : translations.fileUpload.addAnother.de}
+            </span>
+          </label>
+        </>
       ) : (
-        <label htmlFor={name} className={"flex flex-col md:flex-row"}>
-          {jsAvailable ? (
-            <div className="ds-button ds-button-tertiary ds-button-large">
-              <span className="ds-button-label">
-                {splitFieldName(name).inputIndex === 0
-                  ? translations.fileUpload.select.de
-                  : translations.fileUpload.addAnother.de}
-              </span>
-              {FileInput}
-            </div>
-          ) : (
-            <>
-              {FileInput}
-              <Button
-                name="_action"
-                value={`fileUpload.${name}`}
-                className="w-fit"
-                type="submit"
-                look="primary"
-                text={translations.fileUpload.upload.de}
-                size="large"
-              />
-            </>
-          )}
-        </label>
+        <div className="flex flex-row">
+          {FileInput}
+          <Button
+            name="_action"
+            value={`fileUpload.${name}`}
+            className="w-fit"
+            type="submit"
+            look="primary"
+            text={translations.fileUpload.upload.de}
+            size="large"
+          />
+        </div>
       )}
-      <InputError id={errorId}>
-        {errorMessages?.find((err) => err.code === error)?.text ?? error}
-      </InputError>
-      <div className="label-text mt-6">{helperText}</div>
-    </div>
+      {helperText && <div className="label-text mt-6">{helperText}</div>}
+    </>
   );
 };

--- a/app/components/inputs/__test__/FileInput.test.tsx
+++ b/app/components/inputs/__test__/FileInput.test.tsx
@@ -24,10 +24,7 @@ describe("FileInput", () => {
     );
     expect(getByText(selectFilesButtonLabel)).toBeInTheDocument();
     const input = getByTestId("file-upload-input-belege[0]");
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveClass(
-      "w-0.1 h-0.1 opacity-0 overflow-hidden absolute z-0 cursor-pointer",
-    );
+    expect(input).toHaveClass("hidden");
     expect(getByText(selectFilesButtonLabel)).toBeInTheDocument();
     expect(getByText(helperText)).toBeInTheDocument();
   });


### PR DESCRIPTION
Current: When you hover over file upload component the cursor doesnt turn into cursor

Also refactored out some unused divs and an issue when resizing the screen and the file name is too long it would break the whole container down