### PR TITLE
refactor(Tiles): move transform into schema

### DIFF
--- a/app/components/inputs/tile/TileRadio.tsx
+++ b/app/components/inputs/tile/TileRadio.tsx
@@ -91,7 +91,9 @@ function TileRadio({
             <TileTag tagDescription={tagDescription} />
           </div>
           <span className="ds-label-01-bold">{title}</span>
-          {description && <RichText html={description} />}
+          {description && (
+            <RichText className="ds-subhead" html={description} />
+          )}
         </div>
       </label>
     </div>

--- a/app/services/cms/models/StrapiTile.ts
+++ b/app/services/cms/models/StrapiTile.ts
@@ -1,32 +1,15 @@
-import { type Renderer } from "marked";
 import { z } from "zod";
-import { buildRichTextValidation } from "~/services/validation/richtext";
+import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
+import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
 import { StrapiImageOptionalSchema } from "./StrapiImage";
-
-export const createTileRenderer = (value: string): Partial<Renderer> => ({
-  paragraph({ text }) {
-    return `<p id="${value}-description" class="ds-subhead">${text}</p>`;
-  },
-});
 
 export const StrapiTileSchema = z
   .object({
     title: z.string(),
     value: z.string(),
-    description: z.string().nullable(),
+    description: StrapiRichTextOptionalSchema(),
     image: StrapiImageOptionalSchema,
-    tagDescription: z.string().nullable(),
+    tagDescription: z.string().nullable().transform(omitNull),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .transform((cmsData) => {
-    const tileRenderer = createTileRenderer(cmsData.value);
-    const parsed = buildRichTextValidation(tileRenderer)
-      .nullable()
-      .safeParse(cmsData.description);
-
-    return {
-      ...cmsData,
-      description: parsed.success ? parsed.data : null,
-    };
-  });
+  .merge(HasOptionalStrapiIdSchema);

--- a/app/services/cms/models/__test__/StrapiTile.test.ts
+++ b/app/services/cms/models/__test__/StrapiTile.test.ts
@@ -44,8 +44,8 @@ describe("StrapiTileSchema", () => {
     expect(actual.data).toEqual({
       title: "something",
       value: "something",
-      tagDescription: null,
-      description: null,
+      tagDescription: undefined,
+      description: undefined,
     });
   });
 
@@ -64,8 +64,10 @@ describe("StrapiTileSchema", () => {
     expect(actual.data).toEqual({
       title: "something",
       value: "something",
-      tagDescription: null,
-      description: `<p id="something-description" class="ds-subhead">description</p>`,
+      tagDescription: undefined,
+      image: undefined,
+      description: `<p>description</p>
+`,
     });
   });
 });

--- a/app/services/validation/__test__/richtext.test.ts
+++ b/app/services/validation/__test__/richtext.test.ts
@@ -1,6 +1,5 @@
 import { type SafeParseError } from "zod";
 import { listRenderer } from "~/services/cms/models/StrapiList";
-import { createTileRenderer } from "~/services/cms/models/StrapiTile";
 import { buildRichTextValidation } from "~/services/validation/richtext";
 
 describe("richtext validation", () => {
@@ -46,17 +45,6 @@ describe("richtext validation", () => {
   });
 
   describe("custom renderers", () => {
-    test("uses custom tile renderer", () => {
-      const paragraphText = "Some paragraph";
-      const tileRenderer = createTileRenderer("some-value");
-      expect(
-        buildRichTextValidation(tileRenderer).safeParse(paragraphText),
-      ).toEqual({
-        data: `<p id="some-value-description" class="ds-subhead">${paragraphText}</p>`,
-        success: true,
-      });
-    });
-
     test("uses custom list renderer", () => {
       const paragraphText = "Some paragraph";
       expect(

--- a/tests/factories/cmsModels/strapiTileGroupComponent.ts
+++ b/tests/factories/cmsModels/strapiTileGroupComponent.ts
@@ -17,8 +17,6 @@ export function getStrapiTileGroupComponent(
       options: tiles.map((title, index) => ({
         title,
         value: `tile ${index}`,
-        description: null,
-        tagDescription: null,
       })),
       errors: [
         {


### PR DESCRIPTION
just came across this slightly complex schema and cleaned up the transformation a little bit.

I would also propose to delete the `StrapiTile.test.ts` since it now only tests uninteresting zod library code