### PR TITLE
refactor(StrapiFormComponents): transform in schema

### DIFF
--- a/app/routes/shared/vorabcheck.server.ts
+++ b/app/routes/shared/vorabcheck.server.ts
@@ -80,7 +80,7 @@ export const loader = async ({
       strapiFormElement.label === null &&
       headings.length > 0
     ) {
-      strapiFormElement.altLabel = headings[0].text ?? null;
+      strapiFormElement.altLabel = headings[0].text;
     }
     return strapiFormElement;
   });

--- a/app/services/cms/__test__/index.test.ts
+++ b/app/services/cms/__test__/index.test.ts
@@ -10,6 +10,7 @@ import {
 } from "~/services/cms/index.server";
 import { StrapiFooterSchema } from "~/services/cms/models/StrapiFooter";
 import { type StrapiSchemas } from "~/services/cms/schemas";
+import { StrapiInputComponentSchema } from "../components/StrapiInput";
 import { fetchAllFormFields } from "../fetchAllFormFields";
 import { getStrapiEntry } from "../getStrapiEntry";
 
@@ -31,21 +32,27 @@ describe("services/cms", () => {
 
   describe("fetchEntries", () => {
     test("returns a list of entries", async () => {
+      const component1 = getStrapiFormComponent({ name: "formFieldForStep1" });
+      const component2 = getStrapiFormComponent({ name: "formFieldForStep2" });
       const strapiPages = [
-        getStrapiFlowPage({
-          stepId: "step1",
-          form: [getStrapiFormComponent({ name: "formFieldForStep1" })],
-        }),
-
-        getStrapiFlowPage({
-          stepId: "step2",
-          form: [getStrapiFormComponent({ name: "formFieldForStep2" })],
-        }),
+        getStrapiFlowPage({ stepId: "step1", form: [component1] }),
+        getStrapiFlowPage({ stepId: "step2", form: [component2] }),
       ];
       vi.mocked(getStrapiEntry).mockResolvedValue(strapiPages);
 
+      const expected = [
+        {
+          ...strapiPages[0],
+          form: [StrapiInputComponentSchema.parse(component1)],
+        },
+        {
+          ...strapiPages[1],
+          form: [StrapiInputComponentSchema.parse(component2)],
+        },
+      ];
+
       expect(await fetchEntries({ apiId: "form-flow-pages" })).toEqual(
-        strapiPages,
+        expected,
       );
     });
   });

--- a/app/services/cms/components/StrapiAutoSuggestInput.ts
+++ b/app/services/cms/components/StrapiAutoSuggestInput.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import {
@@ -27,7 +24,7 @@ export const StrapiAutoSuggestInputComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));
 
 export type DataListType = z.infer<typeof DataListSchema>;

--- a/app/services/cms/components/StrapiAutoSuggestInput.ts
+++ b/app/services/cms/components/StrapiAutoSuggestInput.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 import {
   strapiWidthToFieldWidth,
   strapiWidthSchema,
@@ -12,12 +12,12 @@ const DataListSchema = z.enum(["airports", "airlines"]);
 export const StrapiAutoSuggestInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    placeholder: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     width: strapiWidthSchema.nullable().transform(strapiWidthToFieldWidth),
     dataList: DataListSchema,
-    noSuggestionMessage: z.string().nullable().transform(omitNull),
+    noSuggestionMessage: strapiOptionalStringSchema,
     isDisabled: z.boolean().nullable().transform(Boolean),
     __component: z.literal("form-elements.auto-suggest-input"),
   })

--- a/app/services/cms/components/StrapiAutoSuggestInput.ts
+++ b/app/services/cms/components/StrapiAutoSuggestInput.ts
@@ -12,39 +12,22 @@ import {
 
 const DataListSchema = z.enum(["airports", "airlines"]);
 
-const StrapiAutoSuggestInputSchema = z
+export const StrapiAutoSuggestInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable(),
-    placeholder: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
+    placeholder: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
-    width: strapiWidthSchema.nullable(),
+    width: strapiWidthSchema.nullable().transform(strapiWidthToFieldWidth),
     dataList: DataListSchema,
-    noSuggestionMessage: z.string().nullable(),
-    isDisabled: z
-      .boolean()
-      .nullable()
-      .transform((value) => {
-        if (value === null) {
-          return false;
-        }
-
-        return value;
-      }),
+    noSuggestionMessage: z.string().nullable().transform(omitNull),
+    isDisabled: z.boolean().nullable().transform(Boolean),
+    __component: z.literal("form-elements.auto-suggest-input"),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-type StrapiAutoSuggestInput = z.infer<typeof StrapiAutoSuggestInputSchema>;
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+  }));
 
 export type DataListType = z.infer<typeof DataListSchema>;
-
-export const StrapiAutoSuggestInputComponentSchema =
-  StrapiAutoSuggestInputSchema.extend({
-    __component: z.literal("form-elements.auto-suggest-input"),
-  });
-
-export const getAutoSuggestInputProps = (cmsData: StrapiAutoSuggestInput) => ({
-  ...omitNull(cmsData),
-  width: strapiWidthToFieldWidth(cmsData.width),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});

--- a/app/services/cms/components/StrapiAutoSuggestInput.ts
+++ b/app/services/cms/components/StrapiAutoSuggestInput.ts
@@ -2,10 +2,7 @@ import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
-import {
-  strapiWidthToFieldWidth,
-  strapiWidthSchema,
-} from "../models/strapiWidth";
+import { strapiWidthSchema } from "../models/strapiWidth";
 
 const DataListSchema = z.enum(["airports", "airlines"]);
 
@@ -15,7 +12,7 @@ export const StrapiAutoSuggestInputComponentSchema = z
     label: strapiOptionalStringSchema,
     placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
-    width: strapiWidthSchema.nullable().transform(strapiWidthToFieldWidth),
+    width: strapiWidthSchema,
     dataList: DataListSchema,
     noSuggestionMessage: strapiOptionalStringSchema,
     isDisabled: z.boolean().nullable().transform(Boolean),

--- a/app/services/cms/components/StrapiCheckbox.ts
+++ b/app/services/cms/components/StrapiCheckbox.ts
@@ -6,25 +6,17 @@ import {
 } from "../models/HasStrapiId";
 import { StrapiErrorCategorySchema } from "../models/StrapiErrorCategory";
 
-const StrapiCheckboxSchema = z
+export const StrapiCheckboxComponentSchema = z
   .object({
+    __component: z.literal("form-elements.checkbox"),
     name: z.string(),
     label: z.string(),
     isRequiredError:
       StrapiErrorCategorySchema.merge(HasStrapiIdSchema).nullable(),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-type StrapiCheckboxSchema = z.infer<typeof StrapiCheckboxSchema>;
-
-export const StrapiCheckboxComponentSchema = StrapiCheckboxSchema.extend({
-  __component: z.literal("form-elements.checkbox"),
-});
-
-export const getCheckboxProps = (
-  cmsData: StrapiCheckboxSchema,
-): CheckboxProps => ({
-  ...cmsData,
-  required: cmsData.isRequiredError !== null,
-  errorMessage: cmsData.isRequiredError?.errorCodes[0].text,
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ isRequiredError, ...cmsData }) => ({
+    ...cmsData,
+    required: isRequiredError !== null,
+    errorMessage: isRequiredError?.errorCodes[0].text,
+  }));

--- a/app/services/cms/components/StrapiCheckbox.ts
+++ b/app/services/cms/components/StrapiCheckbox.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type CheckboxProps } from "~/components/inputs/Checkbox";
 import {
   HasOptionalStrapiIdSchema,
   HasStrapiIdSchema,

--- a/app/services/cms/components/StrapiDateInput.ts
+++ b/app/services/cms/components/StrapiDateInput.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 
@@ -17,5 +14,5 @@ export const StrapiDateInputComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/components/StrapiDateInput.ts
+++ b/app/services/cms/components/StrapiDateInput.ts
@@ -12,10 +12,10 @@ export const StrapiDateInputComponentSchema = z
     label: z.string().nullable().transform(omitNull),
     placeholder: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
+    __component: z.literal("form-elements.date-input"),
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
     errorMessages: flattenStrapiErrors(errors),
-    __component: "form-elements.date-input" as const,
   }));

--- a/app/services/cms/components/StrapiDateInput.ts
+++ b/app/services/cms/components/StrapiDateInput.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 
 export const StrapiDateInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    placeholder: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     __component: z.literal("form-elements.date-input"),
   })

--- a/app/services/cms/components/StrapiDateInput.ts
+++ b/app/services/cms/components/StrapiDateInput.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type InputProps } from "~/components/inputs/Input";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -7,22 +6,16 @@ import {
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 
-const StrapiDateInputSchema = z
+export const StrapiDateInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable(),
-    placeholder: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
+    placeholder: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-export const StrapiDateInputComponentSchema = StrapiDateInputSchema.extend({
-  __component: z.literal("form-elements.date-input"),
-});
-
-type StrapiDateInput = z.infer<typeof StrapiDateInputSchema>;
-
-export const getDateInputProps = (cmsData: StrapiDateInput): InputProps => ({
-  ...omitNull(cmsData),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+    __component: "form-elements.date-input" as const,
+  }));

--- a/app/services/cms/components/StrapiDropdown.ts
+++ b/app/services/cms/components/StrapiDropdown.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
-import { strapiWidthToFieldWidth } from "../models/strapiWidth";
+import { strapiWidthLookupMap } from "../models/strapiWidth";
 
 export const StrapiDropdownComponentSchema = z
   .object({
@@ -16,10 +16,7 @@ export const StrapiDropdownComponentSchema = z
     width: z
       .enum(["characters16", "characters24", "characters36", "characters54"])
       .nullable()
-      .transform(
-        (val) =>
-          strapiWidthToFieldWidth(val) as "16" | "24" | "36" | "54" | undefined,
-      ),
+      .transform((val) => strapiWidthLookupMap[val ?? ""]),
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({

--- a/app/services/cms/components/StrapiDropdown.ts
+++ b/app/services/cms/components/StrapiDropdown.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 import { strapiWidthToFieldWidth } from "../models/strapiWidth";
 
 export const StrapiDropdownComponentSchema = z
   .object({
     __component: z.literal("form-elements.dropdown"),
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    altLabel: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    altLabel: strapiOptionalStringSchema,
     options: z.array(z.object({ value: z.string(), text: z.string() })),
-    placeholder: z.string().nullable().transform(omitNull),
+    placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     width: z
       .enum(["characters16", "characters24", "characters36", "characters54"])

--- a/app/services/cms/components/StrapiDropdown.ts
+++ b/app/services/cms/components/StrapiDropdown.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { strapiWidthToFieldWidth } from "../models/strapiWidth";
@@ -27,5 +24,5 @@ export const StrapiDropdownComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/components/StrapiFilesUpload.ts
+++ b/app/services/cms/components/StrapiFilesUpload.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type FilesUploadProps } from "~/components/filesUpload/FilesUpload";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -8,27 +7,20 @@ import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { omitNull } from "~/util/omitNull";
 
-const StrapiFilesUploadSchema = z
+export const StrapiFilesUploadComponentSchema = z
   .object({
+    __component: z.literal("form-elements.files-upload"),
     name: z.string(),
     title: z.string(),
-    description: z.string().nullable(),
-    inlineNotices: z.array(StrapiInlineNoticeSchema).optional(),
+    description: z.string().nullable().transform(omitNull),
+    inlineNotices: z
+      .array(StrapiInlineNoticeSchema)
+      .nullable()
+      .transform(omitNull),
     errors: StrapiErrorRelationSchema,
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-export const StrapiFilesUploadComponentSchema = StrapiFilesUploadSchema.extend({
-  __component: z.literal("form-elements.files-upload"),
-});
-
-type StrapiFilesUpload = z.infer<typeof StrapiFilesUploadSchema>;
-
-export function getFilesUploadProps(
-  props: StrapiFilesUpload,
-): FilesUploadProps {
-  return {
-    ...omitNull(props),
-    errorMessages: flattenStrapiErrors(props.errors),
-  };
-}
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+  }));

--- a/app/services/cms/components/StrapiFilesUpload.ts
+++ b/app/services/cms/components/StrapiFilesUpload.ts
@@ -3,13 +3,14 @@ import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { omitNull } from "~/util/omitNull";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 
 export const StrapiFilesUploadComponentSchema = z
   .object({
     __component: z.literal("form-elements.files-upload"),
     name: z.string(),
     title: z.string(),
-    description: z.string().nullable().transform(omitNull),
+    description: strapiOptionalStringSchema,
     inlineNotices: z
       .array(StrapiInlineNoticeSchema)
       .nullable()

--- a/app/services/cms/components/StrapiFilesUpload.ts
+++ b/app/services/cms/components/StrapiFilesUpload.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { omitNull } from "~/util/omitNull";
 

--- a/app/services/cms/components/StrapiFilesUpload.ts
+++ b/app/services/cms/components/StrapiFilesUpload.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { omitNull } from "~/util/omitNull";
@@ -22,5 +19,5 @@ export const StrapiFilesUploadComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -9,7 +9,6 @@ import Select from "~/components/inputs/Select";
 import Textarea from "~/components/inputs/Textarea";
 import TileGroup from "~/components/inputs/tile/TileGroup";
 import TimeInput from "~/components/inputs/TimeInput";
-import { getAutoSuggestInputProps } from "~/services/cms/components/StrapiAutoSuggestInput";
 import { getCheckboxProps } from "~/services/cms/components/StrapiCheckbox";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
@@ -25,7 +24,7 @@ const FormComponent = ({
 }: Readonly<{ component: StrapiFormComponent }>) => {
   switch (component.__component) {
     case "form-elements.auto-suggest-input":
-      return <AutoSuggestInput {...getAutoSuggestInputProps(component)} />;
+      return <AutoSuggestInput {...component} />;
     case "form-elements.input":
       return <Input {...component} />;
     case "form-elements.date-input":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -9,7 +9,6 @@ import Select from "~/components/inputs/Select";
 import Textarea from "~/components/inputs/Textarea";
 import TileGroup from "~/components/inputs/tile/TileGroup";
 import TimeInput from "~/components/inputs/TimeInput";
-import { getCheckboxProps } from "~/services/cms/components/StrapiCheckbox";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
@@ -38,7 +37,7 @@ const FormComponent = ({
     case "form-elements.dropdown":
       return <Select {...getSelectProps(component)} />;
     case "form-elements.checkbox":
-      return <Checkbox {...getCheckboxProps(component)} />;
+      return <Checkbox {...component} />;
     case "form-elements.tile-group":
       return <TileGroup {...getTileGroupProps(component)} />;
     case "form-elements.hidden-input":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -14,7 +14,6 @@ import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
-import { getSelectProps } from "./StrapiDropdown";
 
 const FormComponent = ({
   component,
@@ -35,7 +34,7 @@ const FormComponent = ({
     case "form-elements.select":
       return <RadioGroup {...component} />;
     case "form-elements.dropdown":
-      return <Select {...getSelectProps(component)} />;
+      return <Select {...component} />;
     case "form-elements.checkbox":
       return <Checkbox {...component} />;
     case "form-elements.tile-group":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -14,7 +14,6 @@ import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
 import { getTextareaProps } from "~/services/cms/components/StrapiTextarea";
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
-import { getTimeInputProps } from "~/services/cms/components/StrapiTimeInput";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
 import { getSelectProps } from "./StrapiDropdown";
@@ -30,7 +29,7 @@ const FormComponent = ({
     case "form-elements.date-input":
       return <DateInput {...component} />;
     case "form-elements.time-input":
-      return <TimeInput {...getTimeInputProps(component)} />;
+      return <TimeInput {...component} />;
     case "form-elements.files-upload":
       return <FilesUpload {...getFilesUploadProps(component)} />;
     case "form-elements.textarea":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -10,7 +10,6 @@ import Textarea from "~/components/inputs/Textarea";
 import TileGroup from "~/components/inputs/tile/TileGroup";
 import TimeInput from "~/components/inputs/TimeInput";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
-import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
 
@@ -39,7 +38,7 @@ const FormComponent = ({
     case "form-elements.tile-group":
       return <TileGroup {...component} />;
     case "form-elements.hidden-input":
-      return <HiddenInput {...getHiddenInputProps(component)} />;
+      return <HiddenInput {...component} />;
   }
 };
 

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -14,7 +14,6 @@ import { getCheckboxProps } from "~/services/cms/components/StrapiCheckbox";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
 import { getInputProps } from "~/services/cms/components/StrapiInput";
-import { getRadioGroupProps } from "~/services/cms/components/StrapiSelect";
 import { getTextareaProps } from "~/services/cms/components/StrapiTextarea";
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { getTimeInputProps } from "~/services/cms/components/StrapiTimeInput";
@@ -40,7 +39,7 @@ const FormComponent = ({
     case "form-elements.textarea":
       return <Textarea {...getTextareaProps(component)} />;
     case "form-elements.select":
-      return <RadioGroup {...getRadioGroupProps(component)} />;
+      return <RadioGroup {...component} />;
     case "form-elements.dropdown":
       return <Select {...getSelectProps(component)} />;
     case "form-elements.checkbox":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -9,7 +9,6 @@ import Select from "~/components/inputs/Select";
 import Textarea from "~/components/inputs/Textarea";
 import TileGroup from "~/components/inputs/tile/TileGroup";
 import TimeInput from "~/components/inputs/TimeInput";
-import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
 
@@ -26,7 +25,7 @@ const FormComponent = ({
     case "form-elements.time-input":
       return <TimeInput {...component} />;
     case "form-elements.files-upload":
-      return <FilesUpload {...getFilesUploadProps(component)} />;
+      return <FilesUpload {...component} />;
     case "form-elements.textarea":
       return <Textarea {...component} />;
     case "form-elements.select":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -12,7 +12,6 @@ import TimeInput from "~/components/inputs/TimeInput";
 import { getCheckboxProps } from "~/services/cms/components/StrapiCheckbox";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
-import { getTextareaProps } from "~/services/cms/components/StrapiTextarea";
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
@@ -33,7 +32,7 @@ const FormComponent = ({
     case "form-elements.files-upload":
       return <FilesUpload {...getFilesUploadProps(component)} />;
     case "form-elements.textarea":
-      return <Textarea {...getTextareaProps(component)} />;
+      return <Textarea {...component} />;
     case "form-elements.select":
       return <RadioGroup {...component} />;
     case "form-elements.dropdown":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -18,7 +18,6 @@ import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { getTimeInputProps } from "~/services/cms/components/StrapiTimeInput";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
-import { getDateInputProps } from "./StrapiDateInput";
 import { getSelectProps } from "./StrapiDropdown";
 
 const FormComponent = ({
@@ -30,7 +29,7 @@ const FormComponent = ({
     case "form-elements.input":
       return <Input {...component} />;
     case "form-elements.date-input":
-      return <DateInput {...getDateInputProps(component)} />;
+      return <DateInput {...component} />;
     case "form-elements.time-input":
       return <TimeInput {...getTimeInputProps(component)} />;
     case "form-elements.files-upload":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -13,7 +13,6 @@ import { getAutoSuggestInputProps } from "~/services/cms/components/StrapiAutoSu
 import { getCheckboxProps } from "~/services/cms/components/StrapiCheckbox";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
-import { getInputProps } from "~/services/cms/components/StrapiInput";
 import { getTextareaProps } from "~/services/cms/components/StrapiTextarea";
 import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { getTimeInputProps } from "~/services/cms/components/StrapiTimeInput";
@@ -29,7 +28,7 @@ const FormComponent = ({
     case "form-elements.auto-suggest-input":
       return <AutoSuggestInput {...getAutoSuggestInputProps(component)} />;
     case "form-elements.input":
-      return <Input {...getInputProps(component)} />;
+      return <Input {...component} />;
     case "form-elements.date-input":
       return <DateInput {...getDateInputProps(component)} />;
     case "form-elements.time-input":

--- a/app/services/cms/components/StrapiFormComponents.tsx
+++ b/app/services/cms/components/StrapiFormComponents.tsx
@@ -11,7 +11,6 @@ import TileGroup from "~/components/inputs/tile/TileGroup";
 import TimeInput from "~/components/inputs/TimeInput";
 import { getFilesUploadProps } from "~/services/cms/components/StrapiFilesUpload";
 import { getHiddenInputProps } from "~/services/cms/components/StrapiHiddenInput";
-import { getTileGroupProps } from "~/services/cms/components/StrapiTileGroup";
 import { keyFromElement } from "~/services/cms/keyFromElement";
 import { type StrapiFormComponent } from "~/services/cms/models/StrapiFormComponent";
 
@@ -38,7 +37,7 @@ const FormComponent = ({
     case "form-elements.checkbox":
       return <Checkbox {...component} />;
     case "form-elements.tile-group":
-      return <TileGroup {...getTileGroupProps(component)} />;
+      return <TileGroup {...component} />;
     case "form-elements.hidden-input":
       return <HiddenInput {...getHiddenInputProps(component)} />;
   }

--- a/app/services/cms/components/StrapiHiddenInput.ts
+++ b/app/services/cms/components/StrapiHiddenInput.ts
@@ -1,20 +1,9 @@
 import { z } from "zod";
-import { type HiddenInputProps } from "~/components/inputs/HiddenInput";
 import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
-import { omitNull } from "~/util/omitNull";
 
-const StrapiHiddenInputSchema = z
+export const StrapiHiddenInputComponentSchema = z
   .object({
+    __component: z.literal("form-elements.hidden-input"),
     name: z.string(),
   })
   .merge(HasOptionalStrapiIdSchema);
-
-type StrapiHiddenInput = z.infer<typeof StrapiHiddenInputSchema>;
-
-export const StrapiHiddenInputComponentSchema = StrapiHiddenInputSchema.extend({
-  __component: z.literal("form-elements.hidden-input"),
-});
-
-export const getHiddenInputProps = (
-  cmsData: StrapiHiddenInput,
-): HiddenInputProps => omitNull(cmsData);

--- a/app/services/cms/components/StrapiInput.ts
+++ b/app/services/cms/components/StrapiInput.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type InputProps } from "~/components/inputs/Input";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -11,27 +10,20 @@ import {
   strapiWidthToFieldWidth,
 } from "../models/strapiWidth";
 
-const StrapiInputSchema = z
+export const StrapiInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
     type: z.enum(["text", "number"]),
-    placeholder: z.string().nullable(),
-    suffix: z.string().nullable(),
+    placeholder: z.string().nullable().transform(omitNull),
+    suffix: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
-    width: strapiWidthSchema,
-    helperText: z.string().nullable(),
+    width: strapiWidthSchema.transform(strapiWidthToFieldWidth),
+    helperText: z.string().nullable().transform(omitNull),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-type StrapiInput = z.infer<typeof StrapiInputSchema>;
-
-export const StrapiInputComponentSchema = StrapiInputSchema.extend({
-  __component: z.literal("form-elements.input"),
-});
-
-export const getInputProps = (cmsData: StrapiInput): InputProps => ({
-  ...omitNull(cmsData),
-  width: strapiWidthToFieldWidth(cmsData.width),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+    __component: "form-elements.input" as const,
+  }));

--- a/app/services/cms/components/StrapiInput.ts
+++ b/app/services/cms/components/StrapiInput.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 import {
   strapiWidthSchema,
   strapiWidthToFieldWidth,
@@ -10,13 +10,13 @@ import {
 export const StrapiInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
     type: z.enum(["text", "number"]),
-    placeholder: z.string().nullable().transform(omitNull),
-    suffix: z.string().nullable().transform(omitNull),
+    placeholder: strapiOptionalStringSchema,
+    suffix: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     width: strapiWidthSchema.transform(strapiWidthToFieldWidth),
-    helperText: z.string().nullable().transform(omitNull),
+    helperText: strapiOptionalStringSchema,
     __component: z.literal("form-elements.input"),
   })
   .merge(HasOptionalStrapiIdSchema)

--- a/app/services/cms/components/StrapiInput.ts
+++ b/app/services/cms/components/StrapiInput.ts
@@ -20,10 +20,10 @@ export const StrapiInputComponentSchema = z
     errors: StrapiErrorRelationSchema,
     width: strapiWidthSchema.transform(strapiWidthToFieldWidth),
     helperText: z.string().nullable().transform(omitNull),
+    __component: z.literal("form-elements.input"),
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
     errorMessages: flattenStrapiErrors(errors),
-    __component: "form-elements.input" as const,
   }));

--- a/app/services/cms/components/StrapiInput.ts
+++ b/app/services/cms/components/StrapiInput.ts
@@ -2,10 +2,7 @@ import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
-import {
-  strapiWidthSchema,
-  strapiWidthToFieldWidth,
-} from "../models/strapiWidth";
+import { strapiWidthSchema } from "../models/strapiWidth";
 
 export const StrapiInputComponentSchema = z
   .object({
@@ -15,7 +12,7 @@ export const StrapiInputComponentSchema = z
     placeholder: strapiOptionalStringSchema,
     suffix: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
-    width: strapiWidthSchema.transform(strapiWidthToFieldWidth),
+    width: strapiWidthSchema,
     helperText: strapiOptionalStringSchema,
     __component: z.literal("form-elements.input"),
   })

--- a/app/services/cms/components/StrapiInput.ts
+++ b/app/services/cms/components/StrapiInput.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import {
@@ -25,5 +22,5 @@ export const StrapiInputComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/components/StrapiSelect.ts
+++ b/app/services/cms/components/StrapiSelect.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 import { StrapiSelectOptionSchema } from "../models/StrapiSelectOption";
 
 export const StrapiSelectComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    altLabel: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    altLabel: strapiOptionalStringSchema,
     options: z.array(StrapiSelectOptionSchema),
     errors: StrapiErrorRelationSchema,
   })

--- a/app/services/cms/components/StrapiSelect.ts
+++ b/app/services/cms/components/StrapiSelect.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type RadioGroupProps } from "~/components/inputs/RadioGroup";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -8,26 +7,17 @@ import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { StrapiSelectOptionSchema } from "../models/StrapiSelectOption";
 
-const StrapiSelectSchema = z
+export const StrapiSelectComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable(),
-    altLabel: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
+    altLabel: z.string().nullable().transform(omitNull),
     options: z.array(StrapiSelectOptionSchema),
-    errors: StrapiErrorRelationSchema,
+    errors: StrapiErrorRelationSchema.transform(flattenStrapiErrors).optional(),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-type StrapiSelect = z.infer<typeof StrapiSelectSchema>;
-
-export const StrapiSelectComponentSchema = StrapiSelectSchema.extend({
-  __component: z.literal("form-elements.select"),
-});
-
-/**
- * A Strapi "select" is really just a Radio Group
- */
-export const getRadioGroupProps = (cmsData: StrapiSelect): RadioGroupProps => ({
-  ...omitNull(cmsData),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: errors,
+    __component: "form-elements.select" as const,
+  }));

--- a/app/services/cms/components/StrapiSelect.ts
+++ b/app/services/cms/components/StrapiSelect.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 import { StrapiSelectOptionSchema } from "../models/StrapiSelectOption";
@@ -13,7 +10,7 @@ export const StrapiSelectComponentSchema = z
     label: z.string().nullable().transform(omitNull),
     altLabel: z.string().nullable().transform(omitNull),
     options: z.array(StrapiSelectOptionSchema),
-    errors: StrapiErrorRelationSchema.transform(flattenStrapiErrors).optional(),
+    errors: StrapiErrorRelationSchema,
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({

--- a/app/services/cms/components/StrapiTextarea.ts
+++ b/app/services/cms/components/StrapiTextarea.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { StrapiDetailsSchema } from "~/services/cms/models/StrapiDetails";
 import { buildRichTextValidation } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
@@ -22,5 +19,5 @@ export const StrapiTextareaComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/components/StrapiTextarea.ts
+++ b/app/services/cms/components/StrapiTextarea.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { StrapiDetailsSchema } from "~/services/cms/models/StrapiDetails";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { buildRichTextValidation } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";

--- a/app/services/cms/components/StrapiTextarea.ts
+++ b/app/services/cms/components/StrapiTextarea.ts
@@ -4,6 +4,7 @@ import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRela
 import { buildRichTextValidation } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 
 export const StrapiTextareaComponentSchema = z
   .object({
@@ -11,8 +12,8 @@ export const StrapiTextareaComponentSchema = z
     name: z.string(),
     description: buildRichTextValidation().nullable().transform(omitNull),
     details: StrapiDetailsSchema.nullable().transform(omitNull),
-    label: z.string().nullable().transform(omitNull),
-    placeholder: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     maxLength: z.number().nullable().transform(omitNull),
   })

--- a/app/services/cms/components/StrapiTextarea.ts
+++ b/app/services/cms/components/StrapiTextarea.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type TextareaProps } from "~/components/inputs/Textarea";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -9,25 +8,19 @@ import { buildRichTextValidation } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 
-const StrapiTextareaSchema = z
+export const StrapiTextareaComponentSchema = z
   .object({
+    __component: z.literal("form-elements.textarea"),
     name: z.string(),
-    description: buildRichTextValidation().nullable(),
-    details: StrapiDetailsSchema.nullable(),
-    label: z.string().nullable(),
-    placeholder: z.string().nullable(),
+    description: buildRichTextValidation().nullable().transform(omitNull),
+    details: StrapiDetailsSchema.nullable().transform(omitNull),
+    label: z.string().nullable().transform(omitNull),
+    placeholder: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
-    maxLength: z.number().nullable(),
+    maxLength: z.number().nullable().transform(omitNull),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-export const StrapiTextareaComponentSchema = StrapiTextareaSchema.extend({
-  __component: z.literal("form-elements.textarea"),
-});
-
-type StrapiTextarea = z.infer<typeof StrapiTextareaSchema>;
-
-export const getTextareaProps = (cmsData: StrapiTextarea): TextareaProps => ({
-  ...omitNull(cmsData),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+  }));

--- a/app/services/cms/components/StrapiTileGroup.ts
+++ b/app/services/cms/components/StrapiTileGroup.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type TileGroupProps } from "~/components/inputs/tile/TileGroup";
 import { omitNull } from "~/util/omitNull";
 import {
   HasOptionalStrapiIdSchema,
@@ -8,27 +7,18 @@ import {
 import { StrapiErrorCategorySchema } from "../models/StrapiErrorCategory";
 import { StrapiTileSchema } from "../models/StrapiTile";
 
-const StrapiTileGroupSchema = z
+export const StrapiTileGroupComponentSchema = z
   .object({
+    __component: z.literal("form-elements.tile-group"),
     name: z.string(),
-    label: z.string().nullable(),
-    altLabel: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
+    altLabel: z.string().nullable().transform(omitNull),
     options: z.array(StrapiTileSchema),
     errors: z.array(StrapiErrorCategorySchema.merge(HasStrapiIdSchema)),
     useTwoColumns: z.boolean(),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-type StrapiTileGroup = z.infer<typeof StrapiTileGroupSchema>;
-
-export const StrapiTileGroupComponentSchema = StrapiTileGroupSchema.extend({
-  __component: z.literal("form-elements.tile-group"),
-});
-
-export const getTileGroupProps = (
-  cmsData: StrapiTileGroup,
-): TileGroupProps => ({
-  ...omitNull(cmsData),
-  errorMessages: cmsData.errors?.flatMap((cmsError) => cmsError.errorCodes),
-  options: cmsData.options.map((tileOption) => omitNull(tileOption)),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: errors?.flatMap((cmsError) => cmsError.errorCodes),
+  }));

--- a/app/services/cms/components/StrapiTileGroup.ts
+++ b/app/services/cms/components/StrapiTileGroup.ts
@@ -1,18 +1,18 @@
 import { z } from "zod";
-import { omitNull } from "~/util/omitNull";
 import {
   HasOptionalStrapiIdSchema,
   HasStrapiIdSchema,
 } from "../models/HasStrapiId";
 import { StrapiErrorCategorySchema } from "../models/StrapiErrorCategory";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 import { StrapiTileSchema } from "../models/StrapiTile";
 
 export const StrapiTileGroupComponentSchema = z
   .object({
     __component: z.literal("form-elements.tile-group"),
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    altLabel: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    altLabel: strapiOptionalStringSchema,
     options: z.array(StrapiTileSchema),
     errors: z.array(StrapiErrorCategorySchema.merge(HasStrapiIdSchema)),
     useTwoColumns: z.boolean(),

--- a/app/services/cms/components/StrapiTimeInput.ts
+++ b/app/services/cms/components/StrapiTimeInput.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type InputProps } from "~/components/inputs/Input";
 import {
   flattenStrapiErrors,
   StrapiErrorRelationSchema,
@@ -7,22 +6,16 @@ import {
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 
-const StrapiTimeInputSchema = z
+export const StrapiTimeInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable(),
-    placeholder: z.string().nullable(),
+    label: z.string().nullable().transform(omitNull),
+    placeholder: z.string().nullable().transform(omitNull),
     errors: StrapiErrorRelationSchema,
+    __component: z.literal("form-elements.time-input"),
   })
-  .merge(HasOptionalStrapiIdSchema);
-
-export const StrapiTimeInputComponentSchema = StrapiTimeInputSchema.extend({
-  __component: z.literal("form-elements.time-input"),
-});
-
-type StrapiTimeInput = z.infer<typeof StrapiTimeInputSchema>;
-
-export const getTimeInputProps = (cmsData: StrapiTimeInput): InputProps => ({
-  ...omitNull(cmsData),
-  errorMessages: flattenStrapiErrors(cmsData.errors),
-});
+  .merge(HasOptionalStrapiIdSchema)
+  .transform(({ errors, ...cmsData }) => ({
+    ...cmsData,
+    errorMessages: flattenStrapiErrors(errors),
+  }));

--- a/app/services/cms/components/StrapiTimeInput.ts
+++ b/app/services/cms/components/StrapiTimeInput.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
+import { strapiOptionalStringSchema } from "../models/strapiOptionalString";
 
 export const StrapiTimeInputComponentSchema = z
   .object({
     name: z.string(),
-    label: z.string().nullable().transform(omitNull),
-    placeholder: z.string().nullable().transform(omitNull),
+    label: strapiOptionalStringSchema,
+    placeholder: strapiOptionalStringSchema,
     errors: StrapiErrorRelationSchema,
     __component: z.literal("form-elements.time-input"),
   })

--- a/app/services/cms/components/StrapiTimeInput.ts
+++ b/app/services/cms/components/StrapiTimeInput.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  flattenStrapiErrors,
-  StrapiErrorRelationSchema,
-} from "~/services/cms/flattenStrapiErrors";
+import { StrapiErrorRelationSchema } from "~/services/cms/models/StrapiErrorRelationSchema";
 import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "../models/HasStrapiId";
 
@@ -17,5 +14,5 @@ export const StrapiTimeInputComponentSchema = z
   .merge(HasOptionalStrapiIdSchema)
   .transform(({ errors, ...cmsData }) => ({
     ...cmsData,
-    errorMessages: flattenStrapiErrors(errors),
+    errorMessages: errors,
   }));

--- a/app/services/cms/flattenStrapiErrors.ts
+++ b/app/services/cms/flattenStrapiErrors.ts
@@ -4,7 +4,7 @@ import { StrapiErrorCategorySchema } from "~/services/cms/models/StrapiErrorCate
 
 export const StrapiErrorRelationSchema = z
   .array(StrapiErrorCategorySchema.merge(HasStrapiIdSchema))
-  .optional();
+  .nullable();
 
 type StrapiErrorRelation = z.infer<typeof StrapiErrorRelationSchema>;
 

--- a/app/services/cms/models/StrapiAccordion.ts
+++ b/app/services/cms/models/StrapiAccordion.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { HasStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 import { buildRichTextValidation } from "~/services/validation/richtext";
-import { omitNull } from "~/util/omitNull";
+import { strapiOptionalStringSchema } from "./strapiOptionalString";
 
 export const StrapiAccordionSchema = z.object({
   items: z
@@ -10,7 +10,7 @@ export const StrapiAccordionSchema = z.object({
         .object({
           title: z.string(),
           description: buildRichTextValidation(),
-          isVisible: z.string().nullable().transform(omitNull),
+          isVisible: strapiOptionalStringSchema,
         })
         .merge(HasStrapiIdSchema),
     )

--- a/app/services/cms/models/StrapiErrorRelationSchema.ts
+++ b/app/services/cms/models/StrapiErrorRelationSchema.ts
@@ -4,10 +4,5 @@ import { StrapiErrorCategorySchema } from "~/services/cms/models/StrapiErrorCate
 
 export const StrapiErrorRelationSchema = z
   .array(StrapiErrorCategorySchema.merge(HasStrapiIdSchema))
-  .nullable();
-
-type StrapiErrorRelation = z.infer<typeof StrapiErrorRelationSchema>;
-
-export const flattenStrapiErrors = (cmsDataErrors: StrapiErrorRelation) => {
-  return cmsDataErrors?.flatMap((cmsError) => cmsError.errorCodes);
-};
+  .nullable()
+  .transform((errors) => errors?.flatMap((cmsError) => cmsError.errorCodes));

--- a/app/services/cms/models/StrapiFormComponent.ts
+++ b/app/services/cms/models/StrapiFormComponent.ts
@@ -11,7 +11,7 @@ import { StrapiTextareaComponentSchema } from "../components/StrapiTextarea";
 import { StrapiTileGroupComponentSchema } from "../components/StrapiTileGroup";
 import { StrapiTimeInputComponentSchema } from "../components/StrapiTimeInput";
 
-export const StrapiFormComponentSchema = z.discriminatedUnion("__component", [
+export const StrapiFormComponentSchema = z.union([
   StrapiInputComponentSchema,
   StrapiDateInputComponentSchema,
   StrapiTimeInputComponentSchema,

--- a/app/services/cms/models/StrapiTile.ts
+++ b/app/services/cms/models/StrapiTile.ts
@@ -1,6 +1,7 @@
 import { type Renderer } from "marked";
 import { z } from "zod";
 import { buildRichTextValidation } from "~/services/validation/richtext";
+import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
 import { StrapiImageOptionalSchema } from "./StrapiImage";
 
@@ -14,19 +15,18 @@ export const StrapiTileSchema = z
   .object({
     title: z.string(),
     value: z.string(),
-    description: z.string().nullable(),
+    description: z.string().nullable().transform(omitNull),
     image: StrapiImageOptionalSchema,
-    tagDescription: z.string().nullable(),
+    tagDescription: z.string().nullable().transform(omitNull),
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform((cmsData) => {
     const tileRenderer = createTileRenderer(cmsData.value);
-    const parsed = buildRichTextValidation(tileRenderer)
-      .nullable()
-      .safeParse(cmsData.description);
-
+    const parsed = buildRichTextValidation(tileRenderer).safeParse(
+      cmsData.description,
+    );
     return {
       ...cmsData,
-      description: parsed.success ? parsed.data : null,
+      description: parsed.success ? parsed.data : undefined,
     };
   });

--- a/app/services/cms/models/StrapiTile.ts
+++ b/app/services/cms/models/StrapiTile.ts
@@ -1,9 +1,9 @@
 import { type Renderer } from "marked";
 import { z } from "zod";
 import { buildRichTextValidation } from "~/services/validation/richtext";
-import { omitNull } from "~/util/omitNull";
 import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
 import { StrapiImageOptionalSchema } from "./StrapiImage";
+import { strapiOptionalStringSchema } from "./strapiOptionalString";
 
 export const createTileRenderer = (value: string): Partial<Renderer> => ({
   paragraph({ text }) {
@@ -15,9 +15,9 @@ export const StrapiTileSchema = z
   .object({
     title: z.string(),
     value: z.string(),
-    description: z.string().nullable().transform(omitNull),
+    description: strapiOptionalStringSchema,
     image: StrapiImageOptionalSchema,
-    tagDescription: z.string().nullable().transform(omitNull),
+    tagDescription: strapiOptionalStringSchema,
   })
   .merge(HasOptionalStrapiIdSchema)
   .transform((cmsData) => {

--- a/app/services/cms/models/__test__/StrapiTile.test.ts
+++ b/app/services/cms/models/__test__/StrapiTile.test.ts
@@ -44,8 +44,8 @@ describe("StrapiTileSchema", () => {
     expect(actual.data).toEqual({
       title: "something",
       value: "something",
-      tagDescription: null,
-      description: null,
+      tagDescription: undefined,
+      description: undefined,
     });
   });
 
@@ -64,7 +64,7 @@ describe("StrapiTileSchema", () => {
     expect(actual.data).toEqual({
       title: "something",
       value: "something",
-      tagDescription: null,
+      tagDescription: undefined,
       description: `<p id="something-description" class="ds-subhead">description</p>`,
     });
   });

--- a/app/services/cms/models/strapiOptionalString.ts
+++ b/app/services/cms/models/strapiOptionalString.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { omitNull } from "~/util/omitNull";
+
+export const strapiOptionalStringSchema = z
+  .string()
+  .nullable()
+  .transform(omitNull);

--- a/app/services/cms/models/strapiWidth.ts
+++ b/app/services/cms/models/strapiWidth.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { FieldWidth } from "~/components/inputs/width";
 
-const options = [
+const strapiWidths = [
   "characters3",
   "characters5",
   "characters7",
@@ -12,7 +12,7 @@ const options = [
   "characters54",
 ] as const;
 
-const optionsToFieldWidth = {
+export const strapiWidthLookupMap = {
   "": undefined,
   characters3: "3",
   characters5: "5",
@@ -24,8 +24,7 @@ const optionsToFieldWidth = {
   characters54: "54",
 } as const satisfies Record<string, FieldWidth>;
 
-export const strapiWidthSchema = z.enum(options).nullable();
-
-export const strapiWidthToFieldWidth = (
-  strapiWidth: z.infer<typeof strapiWidthSchema>,
-) => optionsToFieldWidth[strapiWidth ?? ""];
+export const strapiWidthSchema = z
+  .enum(strapiWidths)
+  .nullable()
+  .transform((val) => strapiWidthLookupMap[val ?? ""]);

--- a/app/services/flow/formular/contentData/__test__/buildFormElements.test.ts
+++ b/app/services/flow/formular/contentData/__test__/buildFormElements.test.ts
@@ -70,8 +70,9 @@ describe("buildFormElements", () => {
         {
           __component: "form-elements.checkbox",
           label: "some label",
-          isRequiredError: null,
           name: "checkbox",
+          required: false,
+          errorMessage: "",
         },
       ],
     } satisfies CMSContent;

--- a/app/services/flow/formular/contentData/__test__/buildFormElements.test.ts
+++ b/app/services/flow/formular/contentData/__test__/buildFormElements.test.ts
@@ -30,9 +30,9 @@ describe("buildFormElements", () => {
         {
           __component: "form-elements.select",
           name: "someSelect",
-          label: null,
           altLabel: "old alt label",
           options: [],
+          errorMessages: [],
         },
       ],
     } satisfies CMSContent;
@@ -50,9 +50,9 @@ describe("buildFormElements", () => {
         {
           __component: "form-elements.select",
           name: "someSelect",
-          label: null,
           altLabel: "old alt label",
           options: [],
+          errorMessages: [],
         },
       ],
     } satisfies CMSContent;

--- a/app/services/flow/formular/contentData/__test__/getContentData.test.ts
+++ b/app/services/flow/formular/contentData/__test__/getContentData.test.ts
@@ -27,8 +27,9 @@ const mockCmsElement = {
     {
       __component: "form-elements.checkbox",
       label: "some label",
-      isRequiredError: null,
       name: "name",
+      required: false,
+      errorMessage: "",
     },
   ],
   pageMeta: {

--- a/tests/factories/cmsModels/strapiCheckboxComponent.ts
+++ b/tests/factories/cmsModels/strapiCheckboxComponent.ts
@@ -26,11 +26,7 @@ export function getStrapiCheckboxComponent(
       name,
       label,
       id,
-      isRequiredError: {
-        name: "",
-        id: 0,
-        errorCodes: [errorCode],
-      },
+      errorMessage: errorCode.text,
     },
     expectCheckboxErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiDropdownComponent.ts
+++ b/tests/factories/cmsModels/strapiDropdownComponent.ts
@@ -28,13 +28,7 @@ export function getStrapiDropdownComponent(
           value: "option3",
         },
       ],
-      errors: [
-        {
-          name: "",
-          id: 0,
-          errorCodes: [errorCode],
-        },
-      ],
+      errorMessages: [errorCode],
     },
     expectDropdownErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiFlowPage.ts
+++ b/tests/factories/cmsModels/strapiFlowPage.ts
@@ -31,6 +31,7 @@ export function getStrapiFormComponent(
 ): StrapiFormComponentInput {
   return {
     type: faker.helpers.arrayElement(["number", "text"]),
+    __component: "form-elements.input",
     label: faker.lorem.word(),
     name: params.name ?? faker.lorem.word(),
     width: "characters3",

--- a/tests/factories/cmsModels/strapiFlowPage.ts
+++ b/tests/factories/cmsModels/strapiFlowPage.ts
@@ -31,7 +31,6 @@ export function getStrapiFormComponent(
 ): StrapiFormComponentInput {
   return {
     type: faker.helpers.arrayElement(["number", "text"]),
-    __component: "form-elements.input",
     label: faker.lorem.word(),
     name: params.name ?? faker.lorem.word(),
     width: "characters3",

--- a/tests/factories/cmsModels/strapiInputComponent.ts
+++ b/tests/factories/cmsModels/strapiInputComponent.ts
@@ -22,6 +22,7 @@ export function getStrapiInputComponent<T extends InputType = "input">(
       label: "inputLabel",
       placeholder: "placeholder",
       errors: [{ name: "", id: 0, errorCodes: [errorCode] }],
+      errorMessages: [errorCode], // Temporarily support both transformed and untransformed error messages
     },
     expectInputErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiInputComponent.ts
+++ b/tests/factories/cmsModels/strapiInputComponent.ts
@@ -21,8 +21,7 @@ export function getStrapiInputComponent<T extends InputType = "input">(
       name: "inputName",
       label: "inputLabel",
       placeholder: "placeholder",
-      errors: [{ name: "", id: 0, errorCodes: [errorCode] }],
-      errorMessages: [errorCode], // Temporarily support both transformed and untransformed error messages
+      errorMessages: [errorCode],
     },
     expectInputErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiSelectComponent.ts
+++ b/tests/factories/cmsModels/strapiSelectComponent.ts
@@ -23,13 +23,7 @@ export function getStrapiSelectComponent(
           value: "no",
         },
       ],
-      errors: [
-        {
-          name: "",
-          id: 0,
-          errorCodes: [errorCode],
-        },
-      ],
+      errorMessages: [errorCode],
     },
     expectSelectErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiTextareaComponent.ts
+++ b/tests/factories/cmsModels/strapiTextareaComponent.ts
@@ -14,13 +14,7 @@ export function getStrapiTextareaComponent(
       __component: "form-elements.textarea",
       name: `myTextarea`,
       placeholder: `textarea`,
-      errors: [
-        {
-          name: "",
-          id: 0,
-          errorCodes: [errorCode],
-        },
-      ],
+      errorMessages: [errorCode],
     },
     expectTextareaErrorToExist: async function () {
       await waitFor(() => {

--- a/tests/factories/cmsModels/strapiTileGroupComponent.ts
+++ b/tests/factories/cmsModels/strapiTileGroupComponent.ts
@@ -17,16 +17,9 @@ export function getStrapiTileGroupComponent(
       options: tiles.map((title, index) => ({
         title,
         value: `tile ${index}`,
-        description: null,
-        tagDescription: null,
+        description: undefined,
       })),
-      errors: [
-        {
-          name: "",
-          id: 0,
-          errorCodes: [errorCode],
-        },
-      ],
+      errorMessages: [errorCode],
     },
     expectTileGroupErrorToExist: async function () {
       await waitFor(() => {


### PR DESCRIPTION
- aligns the patterns  `StrapiFormComponents` with `PageContent` by moving all transform into the schema
- removes `getXProps()` functions
- simplifies tests