### PR TITLE
feat(posthog): dynamic import

### DIFF
--- a/app/services/analytics/__test__/useInitPosthog.test.ts
+++ b/app/services/analytics/__test__/useInitPosthog.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { PostHog } from "posthog-js";
 import { config } from "~/services/env/public";
 import { useInitPosthog } from "../useInitPosthog";
@@ -13,9 +13,9 @@ describe("useInitPosthog", () => {
     ENVIRONMENT: "test",
   });
 
-  test("returns loaded posthog instance", () => {
+  test("returns loaded posthog instance", async () => {
     const { result } = renderHook(() => useInitPosthog(true));
-    expect(result.current).toBeInstanceOf(PostHog);
+    await waitFor(() => expect(result.current).toBeInstanceOf(PostHog));
     expect(result.current?.__loaded).toBe(true);
   });
 

--- a/app/services/analytics/useInitPosthog.ts
+++ b/app/services/analytics/useInitPosthog.ts
@@ -1,4 +1,4 @@
-import { posthog, type PostHog } from "posthog-js";
+import { type PostHog } from "posthog-js";
 import { useEffect, useState } from "react";
 import { POSTHOG_API_HOST } from "./config";
 import { config } from "../env/public";
@@ -10,19 +10,27 @@ export const useInitPosthog = (hasTrackingConsent?: boolean) => {
   useEffect(() => {
     if (!POSTHOG_API_KEY || !hasTrackingConsent) return;
 
-    posthog.init(POSTHOG_API_KEY, {
-      api_host: POSTHOG_API_HOST,
-      session_recording: {
-        // Masking input and text elements to prevent sensitive data being shown on replays
-        maskTextSelector: "*",
-        maskAllInputs: true,
-      },
-      cross_subdomain_cookie: false, // set cookie for subdomain only
-      opt_out_capturing_by_default: true,
-      opt_out_persistence_by_default: true,
-      secure_cookie: true,
-      loaded: () => setPosthogClient(posthog),
-    });
+    // Dynamic import here to avoid shipping with disabled cookies (like with a static import)
+    // The dynamic import of posthog-js/dist/surveys avoids fetching it from external URL
+    // @ts-expect-error dynamic import without types, see https://posthog.com/docs/libraries/js#option-2-install-via-package-manager
+    void import("posthog-js/dist/surveys");
+    // void import("posthog-js/dist/recorder"); // Enable if session recording is required
+    void import("posthog-js").then(({ default: posthog }) =>
+      posthog.init(POSTHOG_API_KEY, {
+        api_host: POSTHOG_API_HOST,
+        session_recording: {
+          // Masking input and text elements to prevent sensitive data being shown on replays
+          maskTextSelector: "*",
+          maskAllInputs: true,
+        },
+        disable_surveys: false, // currently used for the "ReportProblem" button. To disable also remove corresponding dynamic import
+        cross_subdomain_cookie: false, // set cookie for subdomain only
+        opt_out_capturing_by_default: true,
+        opt_out_persistence_by_default: true,
+        secure_cookie: true,
+        loaded: () => setPosthogClient(posthog),
+      }),
+    );
   }, [POSTHOG_API_KEY, hasTrackingConsent]);
 
   return posthogClient;


### PR DESCRIPTION
The current posthog behavior:
- main bundle is always loaded (even when declining cookies)
- surveys bundle is dynamically fetched from external

![image](https://github.com/user-attachments/assets/1d13728e-c3db-4818-9689-9601b5cebbdf)


After this change:
- main bundle is loaded dynamically if needed (reduces JS load if cookies are declined)
- survey bundle is immediately served from our server (enables parallelism & bundling)
![image](https://github.com/user-attachments/assets/17987aa1-6d43-4808-a05a-0efe34f6c605)

(note the url for surveys)


