### PR TITLE
bug(Report Problem): wrap container and report problem in a div

### DIFF
--- a/app/routes/beratungshilfe.zustaendiges-gericht.auswahl.$PLZ.tsx
+++ b/app/routes/beratungshilfe.zustaendiges-gericht.auswahl.$PLZ.tsx
@@ -99,58 +99,62 @@ export default function Index() {
           <RichText html={resultListHeading} />
         </CourtFinderHeader>
       </Background>
-      <Container paddingTop="48">
-        <Heading
-          tagName="h2"
-          look="ds-heading-03-reg"
-          text="Geben Sie bitte Ihre genaue Straße und Hausnummer ein"
-          className="pb-16"
-        />
-        <ValidatedForm
-          method="post"
-          schema={courtFinderSchema}
-          defaultValues={{
-            street: "",
-            houseNumber: "",
-          }}
-        >
-          <div className="pb-16 flex flex-wrap md:flex-nowrap gap-8">
-            <AutoSuggestInput
-              label={translations.gerichtFinder.streetName.de}
-              dataList="streetNames"
-              noSuggestionMessage={translations.gerichtFinder.noResultsFound.de}
-              errorMessages={[requiredError]}
-              name={"street"}
-              isDisabled={false}
-              minSuggestCharacters={0}
-            />
-            <div className="max-w-[16ch]">
-              <Input
-                type="number"
-                label={translations.gerichtFinder.houseNumber.de}
-                name={"houseNumber"}
+      <div className="flex-grow">
+        <Container paddingTop="48">
+          <Heading
+            tagName="h2"
+            look="ds-heading-03-reg"
+            text="Geben Sie bitte Ihre genaue Straße und Hausnummer ein"
+            className="pb-16"
+          />
+          <ValidatedForm
+            method="post"
+            schema={courtFinderSchema}
+            defaultValues={{
+              street: "",
+              houseNumber: "",
+            }}
+          >
+            <div className="pb-16 flex flex-wrap md:flex-nowrap gap-8">
+              <AutoSuggestInput
+                label={translations.gerichtFinder.streetName.de}
+                dataList="streetNames"
+                noSuggestionMessage={
+                  translations.gerichtFinder.noResultsFound.de
+                }
                 errorMessages={[requiredError]}
-                // Imposed limit to avoid regex backtracking
-                charLimit={10}
+                name={"street"}
+                isDisabled={false}
+                minSuggestCharacters={0}
               />
+              <div className="max-w-[16ch]">
+                <Input
+                  type="number"
+                  label={translations.gerichtFinder.houseNumber.de}
+                  name={"houseNumber"}
+                  errorMessages={[requiredError]}
+                  // Imposed limit to avoid regex backtracking
+                  charLimit={10}
+                />
+              </div>
             </div>
-          </div>
-          <ButtonContainer>
-            <Button
-              href="/beratungshilfe/zustaendiges-gericht/suche"
-              look="tertiary"
-              size="large"
-              id="backLink"
-            >
-              {common.backButton}
-            </Button>
-            <Button type="submit" size="large" id="weiterButton">
-              {translations.buttonNavigation.nextButtonDefaultLabel.de}
-            </Button>
-          </ButtonContainer>
-        </ValidatedForm>
-      </Container>
-      <div className="flex justify-end w-full px-32 relative">
+            <ButtonContainer>
+              <Button
+                href="/beratungshilfe/zustaendiges-gericht/suche"
+                look="tertiary"
+                size="large"
+                id="backLink"
+              >
+                {common.backButton}
+              </Button>
+              <Button type="submit" size="large" id="weiterButton">
+                {translations.buttonNavigation.nextButtonDefaultLabel.de}
+              </Button>
+            </ButtonContainer>
+          </ValidatedForm>
+        </Container>
+      </div>
+      <div className="flex justify-end w-full px-32 py-32relative">
         <ReportProblem />
       </div>
     </div>

--- a/app/routes/beratungshilfe.zustaendiges-gericht.auswahl.$PLZ.tsx
+++ b/app/routes/beratungshilfe.zustaendiges-gericht.auswahl.$PLZ.tsx
@@ -154,7 +154,7 @@ export default function Index() {
           </ValidatedForm>
         </Container>
       </div>
-      <div className="flex justify-end w-full px-32 py-32relative">
+      <div className="flex justify-end w-full p-32 relative">
         <ReportProblem />
       </div>
     </div>


### PR DESCRIPTION
This PR fixes the Report Problem spacing on the auswahl page by wrapping the container and button in a div

Before

![Screenshot 2025-07-09 at 18 06 17](https://github.com/user-attachments/assets/541e940d-dc5a-4c80-8e96-e37cfbfe2478)

![Screenshot 2025-07-09 at 18 06 06](https://github.com/user-attachments/assets/884db83e-e501-49b7-9ec9-f8ee469a9760)

After

![Screenshot 2025-07-09 at 17 59 14](https://github.com/user-attachments/assets/4c3c97c9-3c10-47d4-a013-b21fb90097e6)

![Screenshot 2025-07-09 at 17 59 25](https://github.com/user-attachments/assets/68a34f4b-468b-4312-9f7d-87826ba2efe0)
