### PR TITLE
Improve Strapi schemas components

### DIFF
--- a/app/components/InfoBox.tsx
+++ b/app/components/InfoBox.tsx
@@ -27,17 +27,7 @@ const InfoBox = ({
           data-testid="info-box-item-container"
         >
           {items.map((item) => (
-            <InfoBoxItem
-              separator={separator}
-              {...item}
-              key={
-                item.identifier ??
-                item.headline?.text ??
-                item.content ??
-                item.label?.text ??
-                ""
-              }
-            />
+            <InfoBoxItem separator={separator} {...item} key={item.id} />
           ))}
         </div>
       )}

--- a/app/components/InfoBoxItem.tsx
+++ b/app/components/InfoBoxItem.tsx
@@ -11,6 +11,7 @@ import Image, { type ImageProps } from "./Image";
 import RichText from "./RichText";
 
 export type InfoBoxItemProps = {
+  id: number; // Strapi id
   identifier?: string;
   label?: HeadingProps;
   headline?: HeadingProps;

--- a/app/components/__test__/InfoBox.test.tsx
+++ b/app/components/__test__/InfoBox.test.tsx
@@ -3,6 +3,7 @@ import InfoBox from "~/components/InfoBox";
 
 const mockInfoBoxItems = [
   {
+    id: 10,
     label: undefined,
     headline: undefined,
     image: undefined,
@@ -10,6 +11,7 @@ const mockInfoBoxItems = [
     buttons: [],
   },
   {
+    id: 11,
     label: undefined,
     headline: undefined,
     image: undefined,

--- a/app/components/__test__/InfoBoxItem.test.tsx
+++ b/app/components/__test__/InfoBoxItem.test.tsx
@@ -6,11 +6,11 @@ const separatorStyleClass =
 
 describe("InfoBoxItem", () => {
   it("has expected class properties when the separator is enabled", () => {
-    const { container } = render(<InfoBoxItem separator={true} />);
+    const { container } = render(<InfoBoxItem id={10} separator={true} />);
     expect(container.querySelector(separatorStyleClass)).toBeInTheDocument();
   });
   it("has expected class properties when the separator is disabled", () => {
-    const { container } = render(<InfoBoxItem separator={false} />);
+    const { container } = render(<InfoBoxItem id={10} separator={false} />);
     expect(
       container.querySelector(separatorStyleClass),
     ).not.toBeInTheDocument();
@@ -21,6 +21,7 @@ describe("InfoBoxItem", () => {
       "Testing an inline notice inside of an InfoBoxItem.";
     const { getByRole } = render(
       <InfoBoxItem
+        id={10}
         inlineNotices={[
           {
             title: inlineNoticeTitle,

--- a/app/components/list/List.tsx
+++ b/app/components/list/List.tsx
@@ -33,10 +33,7 @@ const List = ({
           // Need to filter out empty list items when conditionally rendering with mustache templating
           .filter(listItemNotEmpty)
           .map((item, index) => (
-            <li
-              key={item.identifier ?? item.headline?.text ?? item.content}
-              className="group"
-            >
+            <li key={item.id} className="group">
               <ListItem {...item} index={index + 1} variant={variant} />
             </li>
           ))}

--- a/app/components/list/__test__/List.test.tsx
+++ b/app/components/list/__test__/List.test.tsx
@@ -26,10 +26,11 @@ describe("List", () => {
     it("renders <ul> if any item has an image", () => {
       const items: ListItemProps[] = [
         {
+          id: 10,
           headline: { text: "One" },
           image: { url: "/img.png", alternativeText: "" },
         },
-        { headline: { text: "Two" } },
+        { id: 11, headline: { text: "Two" } },
       ];
       const { container } = render(<List items={items} variant="numbered" />);
       expect(container.querySelector("ul")).toBeInTheDocument();
@@ -37,8 +38,8 @@ describe("List", () => {
 
     it("renders <ol> if variant is 'numbered' and no images", () => {
       const items: ListItemProps[] = [
-        { headline: { text: "One" } },
-        { headline: { text: "Two" } },
+        { id: 10, headline: { text: "One" } },
+        { id: 11, headline: { text: "Two" } },
       ];
       const { container } = render(<List items={items} variant="numbered" />);
       expect(container.querySelector("ol")).toBeInTheDocument();
@@ -48,13 +49,13 @@ describe("List", () => {
 
 describe("listItemNotEmpty", () => {
   it("should return true if a ListItem has a headline but no content", () => {
-    const listItem: ListItemProps = { headline: { text: "headline" } };
+    const listItem: ListItemProps = { id: 10, headline: { text: "headline" } };
     expect(listItemNotEmpty(listItem)).toBe(true);
     expect(listItemNotEmpty({ ...listItem, content: "<p></p>\n" })).toBe(true);
   });
 
   it("should return true if a ListItem has content but no headline", () => {
-    const listItem: ListItemProps = { content: "some content" };
+    const listItem: ListItemProps = { id: 10, content: "some content" };
     expect(listItemNotEmpty(listItem)).toBe(true);
     expect(
       listItemNotEmpty({ ...listItem, headline: { text: "\n<h1></h1>" } }),
@@ -63,6 +64,7 @@ describe("listItemNotEmpty", () => {
 
   it("should return true when a ListItem has both headline and content", () => {
     const listItem: ListItemProps = {
+      id: 10,
       headline: { text: "headline" },
       content: "<p>some content</p>",
     };
@@ -70,10 +72,14 @@ describe("listItemNotEmpty", () => {
   });
 
   it("should return false if a ListItem doesn't have headline or content", () => {
-    const listItem: ListItemProps = {};
+    const listItem: ListItemProps = { id: 10 };
     expect(listItemNotEmpty(listItem)).toBe(false);
     expect(
-      listItemNotEmpty({ headline: { text: "" }, content: "<h3></h3>\n" }),
+      listItemNotEmpty({
+        id: 11,
+        headline: { text: "" },
+        content: "<h3></h3>\n",
+      }),
     ).toBe(false);
   });
 });

--- a/app/components/list/__test__/ListItem.test.tsx
+++ b/app/components/list/__test__/ListItem.test.tsx
@@ -2,10 +2,13 @@ import { render } from "@testing-library/react";
 import { renderWithRouter } from "~/components/__test__/renderWithRouter";
 import ListItem from "../ListItem";
 
+const ITEM_ID = 10;
+
 describe("ListItem", () => {
   it("headline and content  should be rendered", () => {
     const { getByText } = render(
       <ListItem
+        id={ITEM_ID}
         content="content"
         headline={{ text: "headlineText" }}
         variant="unordered"
@@ -19,20 +22,28 @@ describe("ListItem", () => {
     const variantsWithIndexLabel = ["numbered", "stepByStep"] as const;
     variantsWithIndexLabel.forEach((variant) => {
       it(`should render indexLabel for ${variant}`, () => {
-        const { getByText } = render(<ListItem index={1} variant={variant} />);
+        const { getByText } = render(
+          <ListItem id={ITEM_ID} index={1} variant={variant} />,
+        );
         expect(getByText("1")).toBeInTheDocument();
       });
     });
   });
 
   it("renders no indexLabel for unordered", () => {
-    const { queryByText } = render(<ListItem index={1} variant="unordered" />);
+    const { queryByText } = render(
+      <ListItem id={ITEM_ID} index={1} variant="unordered" />,
+    );
     expect(queryByText("1")).not.toBeInTheDocument();
   });
 
   it("should render buttons with labels", () => {
     const { getByText, getByRole } = render(
-      <ListItem buttons={[{ text: "label" }]} variant="numbered" />,
+      <ListItem
+        id={ITEM_ID}
+        buttons={[{ text: "label" }]}
+        variant="numbered"
+      />,
     );
     expect(getByText("label")).toBeInTheDocument();
     expect(getByRole("button")).toBeInTheDocument();
@@ -40,7 +51,7 @@ describe("ListItem", () => {
 
   it("should render no buttons for empty array", () => {
     const { queryByRole } = render(
-      <ListItem buttons={[]} variant="numbered" />,
+      <ListItem id={ITEM_ID} buttons={[]} variant="numbered" />,
     );
     expect(queryByRole("button")).not.toBeInTheDocument();
   });
@@ -48,6 +59,7 @@ describe("ListItem", () => {
   it("should render an accordion", () => {
     const { getByRole } = renderWithRouter(
       <ListItem
+        id={ITEM_ID}
         variant="numbered"
         accordion={{
           items: [{ title: "title", description: "content" }],
@@ -61,7 +73,9 @@ describe("ListItem", () => {
   });
 
   it("should render vertical line in stepByStep", () => {
-    const { container } = render(<ListItem variant="stepByStep" />);
+    const { container } = render(
+      <ListItem id={ITEM_ID} variant="stepByStep" />,
+    );
     expect(container.getElementsByClassName("w-2 h-full")).toHaveLength(1);
   });
 
@@ -69,6 +83,7 @@ describe("ListItem", () => {
     it("should hide the image marker from screen readers", () => {
       const { container } = render(
         <ListItem
+          id={ITEM_ID}
           variant="unordered"
           image={{
             url: "/test.png",
@@ -85,6 +100,7 @@ describe("ListItem", () => {
     it("should render a custom image marker when image props are provided", () => {
       const { container } = render(
         <ListItem
+          id={ITEM_ID}
           variant="unordered"
           image={{
             url: "/test.png",
@@ -99,6 +115,7 @@ describe("ListItem", () => {
     it("should not render the styled marker when image is provided", () => {
       const { container } = render(
         <ListItem
+          id={ITEM_ID}
           variant="numbered"
           index={1}
           image={{
@@ -113,17 +130,23 @@ describe("ListItem", () => {
 
   describe("variant styles", () => {
     it("should apply correct classes for unordered variant", () => {
-      const { container } = render(<ListItem variant="unordered" />);
+      const { container } = render(
+        <ListItem id={ITEM_ID} variant="unordered" />,
+      );
       expect(container.querySelector(".border-black")).toBeInTheDocument();
     });
 
     it("should apply correct classes for numbered variant", () => {
-      const { container } = render(<ListItem variant="numbered" />);
+      const { container } = render(
+        <ListItem id={ITEM_ID} variant="numbered" />,
+      );
       expect(container.querySelector(".border-gray-400")).toBeInTheDocument();
     });
 
     it("should apply correct classes for stepByStep variant", () => {
-      const { container } = render(<ListItem variant="stepByStep" />);
+      const { container } = render(
+        <ListItem id={ITEM_ID} variant="stepByStep" />,
+      );
       expect(container.querySelector(".bg-blue-800")).toBeInTheDocument();
     });
   });

--- a/app/components/list/types.ts
+++ b/app/components/list/types.ts
@@ -4,6 +4,7 @@ import { type HeadingProps } from "../Heading";
 import { type ImageProps } from "../Image";
 
 export type ListItemProps = {
+  id: number; // Strapi id
   identifier?: string;
   headline?: HeadingProps;
   content?: string;

--- a/app/services/cms/components/StrapiEmailCapture.ts
+++ b/app/services/cms/components/StrapiEmailCapture.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
+import { HasStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { StrapiOptionalStringSchema } from "~/services/cms/models/StrapiOptionalString";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
@@ -14,4 +14,4 @@ export const StrapiEmailCaptureSchema = z
     errorBanner: StrapiInlineNoticeSchema,
     __component: z.literal("page.email-capture"),
   })
-  .merge(HasOptionalStrapiIdSchema);
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/StrapiArraySummary.ts
+++ b/app/services/cms/models/StrapiArraySummary.ts
@@ -1,14 +1,10 @@
 import { z } from "zod";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 
-const StrapiArraySummarySchema = z
+export const StrapiArraySummaryComponentSchema = z
   .object({
     category: z.string(),
     categoryUrl: z.string(),
-  })
-  .merge(HasOptionalStrapiIdSchema);
-
-export const StrapiArraySummaryComponentSchema =
-  StrapiArraySummarySchema.extend({
     __component: z.literal("page.array-summary"),
-  });
+  })
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/StrapiBox.ts
+++ b/app/services/cms/models/StrapiBox.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiButtonSchema } from "./StrapiButton";
@@ -16,10 +16,7 @@ export const StrapiBoxSchema = z
     outerBackground: StrapiBackgroundOptionalSchema,
     container: StrapiContainerSchema,
     buttons: z.array(StrapiButtonSchema).nullable().transform(omitNull),
+    __component: z.literal("page.box"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.box" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiBoxWithImage.ts
+++ b/app/services/cms/models/StrapiBoxWithImage.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { variantWidths, type Variant } from "~/components/BoxWithImage";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiContainerSchema } from "./StrapiContainer";
@@ -25,10 +25,7 @@ export const StrapiBoxWithImageSchema = z
       .nullable()
       .transform(omitNull),
     container: StrapiContainerSchema,
+    __component: z.literal("page.box-with-image"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.box-with-image" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiDetails.ts
+++ b/app/services/cms/models/StrapiDetails.ts
@@ -1,14 +1,11 @@
 import { z } from "zod";
 import { buildRichTextValidation } from "~/services/validation/richtext";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 
 export const StrapiDetailsSchema = z
   .object({
     title: z.string(),
     content: buildRichTextValidation(),
+    __component: z.literal("page.details-summary"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .transform((cmsData) => ({
-    __component: "page.details-summary" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/StrapiHeading.ts
+++ b/app/services/cms/models/StrapiHeading.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { StringWithHtmlEntities } from "./StringWithHtmlEntities";
 
 export const StrapiHeadingSchema = z
@@ -24,14 +24,9 @@ export const StrapiHeadingSchema = z
       "ds-body-01-reg",
       "ds-body-02-reg",
     ]),
+    __component: z.literal("basic.heading"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .transform((cmsData) => {
-    return {
-      __component: "basic.heading" as const,
-      ...cmsData,
-    };
-  });
+  .merge(HasStrapiIdSchema);
 
 export const StrapiHeadingOptionalSchema =
   StrapiHeadingSchema.nullable().transform(omitNull);

--- a/app/services/cms/models/StrapiHero.ts
+++ b/app/services/cms/models/StrapiHero.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiButtonSchema } from "./StrapiButton";
 import { StrapiHeadingSchema } from "./StrapiHeading";
@@ -12,9 +12,6 @@ export const StrapiHeroSchema = z
     content: StrapiParagraphSchema.nullable().transform(omitNull),
     outerBackground: StrapiBackgroundOptionalSchema,
     button: StrapiButtonSchema.nullable().transform(omitNull),
+    __component: z.literal("page.hero"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .transform((cmsData) => ({
-    __component: "page.hero" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/StrapiImage.ts
+++ b/app/services/cms/models/StrapiImage.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { StrapiStringOptionalSchema } from "~/services/cms/models/StrapiStringOptional";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
 
 function appendStrapiUrlOnDev(imageUrl: string) {
   // Without S3 bucket, Strapi returns relative URLs
@@ -16,14 +15,12 @@ function appendStrapiUrlOnDev(imageUrl: string) {
   return strapiUrl + imageUrl;
 }
 
-export const StrapiImageSchema = z
-  .object({
-    url: z.string().transform(appendStrapiUrlOnDev),
-    width: z.number(),
-    height: z.number(),
-    alternativeText: StrapiStringOptionalSchema,
-  })
-  .merge(HasOptionalStrapiIdSchema);
+export const StrapiImageSchema = z.object({
+  url: z.string().transform(appendStrapiUrlOnDev),
+  width: z.number(),
+  height: z.number(),
+  alternativeText: StrapiStringOptionalSchema,
+});
 
 export const StrapiImageOptionalSchema =
   StrapiImageSchema.nullable().transform(omitNull);

--- a/app/services/cms/models/StrapiInfoBox.ts
+++ b/app/services/cms/models/StrapiInfoBox.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { StrapiBooleanOptionalSchema } from "~/services/cms/models/StrapiBooleanOptional";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiContainerSchema } from "./StrapiContainer";
@@ -14,10 +14,7 @@ export const StrapiInfoBoxSchema = z
     outerBackground: StrapiBackgroundOptionalSchema,
     separator: StrapiBooleanOptionalSchema,
     container: StrapiContainerSchema,
+    __component: z.literal("page.info-box"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.info-box" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiInfoBoxItem.ts
+++ b/app/services/cms/models/StrapiInfoBoxItem.ts
@@ -3,7 +3,7 @@ import { StrapiHeadingOptionalSchema } from "~/services/cms/models/StrapiHeading
 import { StrapiInlineNoticeSchema } from "~/services/cms/models/StrapiInlineNotice";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiAccordionSchema } from "./StrapiAccordion";
 import { StrapiButtonSchema } from "./StrapiButton";
@@ -21,7 +21,7 @@ export const StrapiInfoBoxItemSchema = z
     buttons: z.array(StrapiButtonSchema),
     accordion: StrapiAccordionSchema.nullable().transform(omitNull),
   })
-  .merge(HasOptionalStrapiIdSchema)
+  .merge(HasStrapiIdSchema)
   .merge(OptionalStrapiLinkIdentifierSchema)
   .transform((cmsData) => ({
     ...cmsData,

--- a/app/services/cms/models/StrapiInlineNotice.ts
+++ b/app/services/cms/models/StrapiInlineNotice.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiContainerSchema } from "./StrapiContainer";
@@ -13,10 +13,7 @@ export const StrapiInlineNoticeSchema = z
     content: StrapiRichTextOptionalSchema(),
     container: StrapiContainerSchema,
     outerBackground: StrapiBackgroundOptionalSchema,
+    __component: z.literal("page.inline-notice"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.inline-notice" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiList.ts
+++ b/app/services/cms/models/StrapiList.ts
@@ -1,7 +1,7 @@
 import { type Renderer } from "marked";
 import { z } from "zod";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiContainerSchema } from "./StrapiContainer";
@@ -24,10 +24,7 @@ export const StrapiListSchema = z
       .default("unordered"),
     outerBackground: StrapiBackgroundOptionalSchema,
     container: StrapiContainerSchema,
+    __component: z.literal("page.list"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.list" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiListItem.ts
+++ b/app/services/cms/models/StrapiListItem.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { StrapiAccordionSchema } from "~/services/cms/models/StrapiAccordion";
 import { StrapiRichTextOptionalSchema } from "~/services/validation/richtext";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiButtonSchema } from "./StrapiButton";
 import { StrapiHeadingOptionalSchema } from "./StrapiHeading";
@@ -16,5 +16,5 @@ export const StrapiListItemSchema = z
     accordion: StrapiAccordionSchema.nullable().transform(omitNull),
     image: StrapiImageOptionalSchema,
   })
-  .merge(HasOptionalStrapiIdSchema)
+  .merge(HasStrapiIdSchema)
   .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiSummaryOverviewSection.ts
+++ b/app/services/cms/models/StrapiSummaryOverviewSection.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { omitNull } from "~/util/omitNull";
-import { HasOptionalStrapiIdSchema, HasStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { StrapiHeadingSchema } from "./StrapiHeading";
 import { StrapiStringOptionalSchema } from "./StrapiStringOptional";
 
@@ -30,4 +30,4 @@ export const StrapiSummaryOverviewSectionSchema = z
     title: StrapiHeadingSchema,
     boxes: z.array(StrapiSummaryOverviewBoxSchema).nonempty(),
   })
-  .merge(HasOptionalStrapiIdSchema);
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/StrapiTableOfContents.ts
+++ b/app/services/cms/models/StrapiTableOfContents.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 import { OptionalStrapiLinkIdentifierSchema } from "./HasStrapiLinkIdentifier";
 import { StrapiBackgroundOptionalSchema } from "./StrapiBackground";
 import { StrapiButtonSchema } from "./StrapiButton";
@@ -15,10 +15,7 @@ export const StrapiTableOfContentsSchema = z
     outerBackground: StrapiBackgroundOptionalSchema,
     container: StrapiContainerSchema,
     links: z.array(StrapiLinkSchema),
+    __component: z.literal("page.table-of-contents"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .merge(OptionalStrapiLinkIdentifierSchema)
-  .transform((cmsData) => ({
-    __component: "page.table-of-contents" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema)
+  .merge(OptionalStrapiLinkIdentifierSchema);

--- a/app/services/cms/models/StrapiUserFeedback.ts
+++ b/app/services/cms/models/StrapiUserFeedback.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
-import { HasOptionalStrapiIdSchema } from "./HasStrapiId";
+import { HasStrapiIdSchema } from "./HasStrapiId";
 
 export const StrapiUserFeedbackSchema = z
   .object({
     headingRating: z.string(),
+    __component: z.literal("page.user-feedback"),
   })
-  .merge(HasOptionalStrapiIdSchema)
+  .merge(HasStrapiIdSchema)
   .transform((cmsData) => ({
     ...cmsData,
-    __component: "page.user-feedback" as const,
     rating: {
       heading: cmsData.headingRating,
     },

--- a/app/services/cms/models/StrapiVideo.ts
+++ b/app/services/cms/models/StrapiVideo.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
-import { HasOptionalStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
+import { HasStrapiIdSchema } from "~/services/cms/models/HasStrapiId";
 
 export const StrapiVideoSchema = z
   .object({
     title: z.string(),
     url: z.string(),
+    __component: z.literal("page.video"),
   })
-  .merge(HasOptionalStrapiIdSchema)
-  .transform((cmsData) => ({
-    __component: "page.video" as const,
-    ...cmsData,
-  }));
+  .merge(HasStrapiIdSchema);

--- a/app/services/cms/models/__test__/StrapiHero.test.ts
+++ b/app/services/cms/models/__test__/StrapiHero.test.ts
@@ -19,11 +19,15 @@ describe("StrapiHero", () => {
         text: "someText",
         tagName: "h1",
         look: "default",
+        __component: "basic.heading",
+        id: 10,
       },
       identifier: null,
       content: null,
       outerBackground: null,
       button: null,
+      __component: "page.hero",
+      id: 10,
     };
 
     const actual = StrapiHeroSchema.safeParse(withCorrectData);
@@ -35,8 +39,10 @@ describe("StrapiHero", () => {
         tagName: "h1",
         look: "default",
         __component: "basic.heading",
+        id: 10,
       },
       __component: "page.hero",
+      id: 10,
     });
   });
 
@@ -46,6 +52,8 @@ describe("StrapiHero", () => {
         text: "someText",
         tagName: "h1",
         look: "default",
+        __component: "basic.heading",
+        id: 10,
       },
       content: null,
       identifier: null,
@@ -58,6 +66,8 @@ describe("StrapiHero", () => {
         fullWidth: false,
         __component: "form-elements.button",
       },
+      id: 10,
+      __component: "page.hero",
     };
 
     const actualWithButton = StrapiHeroSchema.safeParse(withButton);

--- a/app/services/cms/models/__test__/StrapiSummaryOverview.test.ts
+++ b/app/services/cms/models/__test__/StrapiSummaryOverview.test.ts
@@ -46,6 +46,7 @@ describe("StrapiSummaryOverviewSchema", () => {
     const correctSummary = {
       __component: "page.summary-overview-section",
       title: {
+        __component: "basic.heading",
         text: "text",
         tagName: "h1",
         look: "default",

--- a/app/services/cms/models/__test__/StrapiTableOfContentSchema.test.ts
+++ b/app/services/cms/models/__test__/StrapiTableOfContentSchema.test.ts
@@ -19,6 +19,7 @@ describe("StrapiTableOfContentSchema", () => {
 
   it("should return true given container", () => {
     const withContainer = {
+      id: 10,
       identifier: null,
       label: null,
       heading: null,
@@ -30,12 +31,14 @@ describe("StrapiTableOfContentSchema", () => {
         paddingTop: "default",
       },
       links: [],
+      __component: "page.table-of-contents",
     };
 
     const actual = StrapiTableOfContentsSchema.safeParse(withContainer);
 
     expect(actual.success).toBe(true);
     expect(actual.data).toEqual({
+      id: 10,
       label: undefined,
       heading: undefined,
       buttons: [],

--- a/stories/InfoBox.stories.tsx
+++ b/stories/InfoBox.stories.tsx
@@ -17,6 +17,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const defaultArgs = {
+  id: 9,
   identifier: "default-info-box-id",
   heading: {
     text: "Heading text",
@@ -25,6 +26,7 @@ const defaultArgs = {
   },
   items: [
     {
+      id: 10,
       label: { text: "Label", look: "ds-label-01-reg" },
       headline: { text: "Headline", look: "ds-heading-03-reg" },
       image: undefined,
@@ -55,6 +57,7 @@ export const WithImage: Story = {
     ...defaultArgs,
     items: [
       {
+        id: 12,
         label: { text: "Label", look: "ds-label-01-reg" },
         headline: { text: "Headline", look: "ds-heading-03-reg" },
         image: {

--- a/stories/InfoBoxItem.stories.tsx
+++ b/stories/InfoBoxItem.stories.tsx
@@ -16,6 +16,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const defaultArgs: InfoBoxItemProps = {
+  id: 10,
   identifier: "default-info-box-item-id",
   headline: {
     text: "InfoBoxItem Header",

--- a/stories/List.stories.tsx
+++ b/stories/List.stories.tsx
@@ -37,6 +37,7 @@ export const Example: Story = {
     },
     items: [
       {
+        id: 10,
         headline: {
           text: "Custom image override",
           look: "ds-heading-03-reg",
@@ -50,6 +51,7 @@ export const Example: Story = {
         },
       },
       {
+        id: 11,
         headline: {
           text: "Unordered styled marker",
           look: "ds-heading-03-reg",


### PR DESCRIPTION
### Background
To render our list of components on the page, we need to set the key props for the React components (it's mandatory). We use the function `keyFromElement` to get the key, using the `__component` and `id`. The `id` can be undefined for the current schemas, however Strapi always returns an `id`, making the `id` for the schemas redundant.

### Changes

- For page components, use the schema `HasStrapiIdSchema` to force the component have an `id`,
- Remove __component from the `transform` and add to object schema of the components
- Add `id` as props for ListItems and InfoBoxItems
- Get rid of `id` for the `StrapiImageSchema`.

### Following changes
I will do the same changes for components inputs. I haven't done it yet, because it might have too many changes 