### PR TITLE
feat(pdf): properly tag footer for a11y

### DIFF
--- a/app/domains/fluggastrechte/services/pdf/sections/__test__/createBankInformation.test.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/__test__/createBankInformation.test.ts
@@ -15,7 +15,7 @@ describe("createBankInformation", () => {
     const mockStruct = mockPdfKitDocumentStructure();
     const mockDoc = mockPdfKitDocument(mockStruct);
 
-    createBankInformation(mockDoc, mockStruct, userDataMock);
+    createBankInformation(mockDoc, mockStruct, userDataMock, true);
 
     expect(mockDoc.struct).toHaveBeenCalledWith("P", {}, expect.any(Function));
     expect(mockDoc.text).toHaveBeenCalledWith(
@@ -35,7 +35,7 @@ describe("createBankInformation", () => {
       nachname: "Mustermann",
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder);
+    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder, true);
 
     expect(mockDoc.struct).toHaveBeenCalledWith("P", {}, expect.any(Function));
     expect(mockDoc.text).toHaveBeenCalledWith(
@@ -55,7 +55,7 @@ describe("createBankInformation", () => {
       nachname: "Mustermann",
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder);
+    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder, true);
 
     expect(mockDoc.struct).toHaveBeenCalledWith("P", {}, expect.any(Function));
     expect(mockDoc.text).toHaveBeenCalledWith(
@@ -75,7 +75,7 @@ describe("createBankInformation", () => {
       nachname: "Mustermann",
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder);
+    createBankInformation(mockDoc, mockStruct, userDataNoAccountHolder, true);
 
     expect(mockDoc.struct).toHaveBeenCalledWith("P", {}, expect.any(Function));
     expect(mockDoc.text).toHaveBeenCalledWith(
@@ -90,7 +90,7 @@ describe("createBankInformation", () => {
     const mockDoc = mockPdfKitDocument(mockStruct);
     const userDataWithoutIban = { ...userDataMock, iban: undefined };
 
-    createBankInformation(mockDoc, mockStruct, userDataWithoutIban);
+    createBankInformation(mockDoc, mockStruct, userDataWithoutIban, true);
 
     expect(mockDoc.struct).not.toHaveBeenCalled();
     expect(mockDoc.text).not.toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe("createBankInformation", () => {
     const mockStruct = mockPdfKitDocumentStructure();
     const mockDoc = mockPdfKitDocument(mockStruct);
 
-    createBankInformation(mockDoc, mockStruct, userDataMock);
+    createBankInformation(mockDoc, mockStruct, userDataMock, true);
 
     expect(mockDoc.fontSize).toHaveBeenCalledWith(7);
     expect(mockDoc.font).toHaveBeenCalledWith(FONTS_BUNDESSANS_REGULAR);
@@ -110,7 +110,7 @@ describe("createBankInformation", () => {
     const mockStruct = mockPdfKitDocumentStructure();
     const mockDoc = mockPdfKitDocument(mockStruct);
 
-    createBankInformation(mockDoc, mockStruct, userDataMock);
+    createBankInformation(mockDoc, mockStruct, userDataMock, true);
 
     expect(mockDoc.text).toHaveBeenCalledWith(
       expect.any(String),
@@ -127,7 +127,7 @@ describe("createBankInformation", () => {
       kontoinhaber: "Jöhn Dœ!💰",
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataSpecialChars);
+    createBankInformation(mockDoc, mockStruct, userDataSpecialChars, true);
 
     expect(mockDoc.text).toHaveBeenCalledWith(
       "Kontoinhaber: Jöhn Dœ!💰 | IBAN: DE68500123456789000000",
@@ -145,7 +145,7 @@ describe("createBankInformation", () => {
       iban: undefined,
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataWithoutIban);
+    createBankInformation(mockDoc, mockStruct, userDataWithoutIban, true);
 
     expect(mockDoc.text).not.toBeCalled();
   });
@@ -159,8 +159,30 @@ describe("createBankInformation", () => {
       iban: "",
     };
 
-    createBankInformation(mockDoc, mockStruct, userDataWithoutIban);
+    createBankInformation(mockDoc, mockStruct, userDataWithoutIban, true);
 
     expect(mockDoc.text).not.toBeCalled();
+  });
+
+  it("should use struct when isLastPage is true", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const mockDoc = mockPdfKitDocument(mockStruct);
+
+    createBankInformation(mockDoc, mockStruct, userDataMock, true);
+
+    expect(mockDoc.struct).toHaveBeenCalledWith("P", {}, expect.any(Function));
+    expect(mockDoc.markContent).not.toHaveBeenCalled();
+  });
+
+  it("should use Artifact markContent when isLastPage is false", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const mockDoc = mockPdfKitDocument(mockStruct);
+
+    createBankInformation(mockDoc, mockStruct, userDataMock, false);
+
+    expect(mockDoc.markContent).toHaveBeenCalledWith("Artifact", {
+      type: "Pagination",
+    });
+    expect(mockDoc.struct).not.toHaveBeenCalled();
   });
 });

--- a/app/domains/fluggastrechte/services/pdf/sections/__test__/createFooter.test.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/__test__/createFooter.test.ts
@@ -49,4 +49,19 @@ describe("createFooter", () => {
 
     expect(createStamp).toBeCalledTimes(1);
   });
+
+  it("should create 'Sect' struct for each page (totalPages times)", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const totalPages = 3;
+    const mockDoc = mockPdfKitDocument(mockStruct, {
+      start: 1,
+      count: totalPages,
+    });
+
+    createFooter(mockDoc, mockStruct, userDataMock);
+
+    expect(mockDoc.struct).toHaveBeenCalledTimes(totalPages);
+    expect(mockDoc.struct).toHaveBeenCalledWith("Sect");
+    expect(mockStruct.add).toHaveBeenCalledTimes(totalPages);
+  });
 });

--- a/app/domains/fluggastrechte/services/pdf/sections/createBankInformation.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/createBankInformation.ts
@@ -6,10 +6,18 @@ import {
   PDF_MARGIN_HORIZONTAL,
 } from "~/services/pdf/createPdfKitDocument";
 
+function drawBankInfo(doc: PDFKit.PDFDocument, text: string) {
+  doc
+    .fontSize(7)
+    .font(FONTS_BUNDESSANS_REGULAR)
+    .text(text, PDF_MARGIN_HORIZONTAL, PDF_HEIGHT_SEIZE);
+}
+
 export const createBankInformation = (
   doc: typeof PDFDocument,
   footerSect: PDFKit.PDFStructureElement,
   { kontoinhaber, vorname, nachname, iban }: FluggastrechteUserData,
+  isLastPage: boolean,
 ) => {
   const bankAccountHolder =
     typeof kontoinhaber !== "undefined" && kontoinhaber.trim().length > 0
@@ -18,13 +26,16 @@ export const createBankInformation = (
 
   if (iban) {
     const bankInfo = `Kontoinhaber: ${bankAccountHolder} | IBAN: ${iban}`;
-    footerSect.add(
-      doc.struct("P", {}, () => {
-        doc
-          .fontSize(7)
-          .font(FONTS_BUNDESSANS_REGULAR)
-          .text(bankInfo, PDF_MARGIN_HORIZONTAL, PDF_HEIGHT_SEIZE);
-      }),
-    );
+
+    if (isLastPage) {
+      const bankInfoParagraph = doc.struct("P", {}, () => {
+        drawBankInfo(doc, bankInfo);
+      });
+      footerSect.add(bankInfoParagraph);
+    } else {
+      doc.markContent("Artifact", { type: "Pagination" });
+      drawBankInfo(doc, bankInfo);
+      doc.endMarkedContent();
+    }
   }
 };

--- a/app/domains/fluggastrechte/services/pdf/sections/createFooter.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/createFooter.ts
@@ -10,13 +10,19 @@ export const createFooter = (
   userData: FluggastrechteUserData,
 ) => {
   const pages = doc.bufferedPageRange();
-  for (let i = 0; i < pages.count; i++) {
-    const footerSect = doc.struct("Sect");
-    doc.switchToPage(i);
+  const totalPages = pages.count;
 
-    createStamp(doc, footerSect);
-    createPageNumber(doc, footerSect, i + 1, pages.count);
-    createBankInformation(doc, footerSect, userData);
+  for (let pageIndex = 0; pageIndex < totalPages; pageIndex++) {
+    const footerSect = doc.struct("Sect");
+    doc.switchToPage(pageIndex);
+
+    const isLastPage = pageIndex === totalPages - 1;
+
+    createStamp(doc, footerSect, isLastPage);
+
+    createPageNumber(doc, footerSect, pageIndex + 1, totalPages);
+
+    createBankInformation(doc, footerSect, userData, isLastPage);
     documentStruct.add(footerSect);
   }
 };

--- a/app/services/pdf/footer/__test__/createFooter.test.ts
+++ b/app/services/pdf/footer/__test__/createFooter.test.ts
@@ -35,4 +35,19 @@ describe("createFooter", () => {
 
     expect(createStamp).toBeCalledTimes(1);
   });
+
+  it("should create 'Sect' struct for each page (totalPages times)", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const totalPages = 3;
+    const mockDoc = mockPdfKitDocument(mockStruct, {
+      start: 1,
+      count: totalPages,
+    });
+
+    createFooter(mockDoc, mockStruct, "Anhang");
+
+    expect(mockDoc.struct).toHaveBeenCalledTimes(totalPages);
+    expect(mockDoc.struct).toHaveBeenCalledWith("Sect");
+    expect(mockStruct.add).toHaveBeenCalledTimes(totalPages);
+  });
 });

--- a/app/services/pdf/footer/__test__/createStamp.test.ts
+++ b/app/services/pdf/footer/__test__/createStamp.test.ts
@@ -9,7 +9,7 @@ describe("createStamp", () => {
     const mockStruct = mockPdfKitDocumentStructure();
     const mockDoc = mockPdfKitDocument(mockStruct);
 
-    createStamp(mockDoc, mockStruct);
+    createStamp(mockDoc, mockStruct, true);
 
     const structMock = mockDoc.struct;
 
@@ -24,5 +24,47 @@ describe("createStamp", () => {
         width: STAMP_TEXT_WIDTH,
       },
     );
+  });
+
+  it("should create artifact content when isLastPage is false", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const mockDoc = mockPdfKitDocument(mockStruct);
+
+    createStamp(mockDoc, mockStruct, false);
+
+    expect(mockDoc.struct).not.toHaveBeenCalledWith(
+      "P",
+      {},
+      expect.any(Function),
+    );
+    expect(mockDoc.markContent).toHaveBeenCalledWith("Artifact", {
+      type: "Pagination",
+    });
+    expect(mockDoc.text).toHaveBeenCalledWith(
+      STAMP_TEXT,
+      expect.anything(),
+      expect.anything(),
+      {
+        align: "center",
+        baseline: "middle",
+        width: STAMP_TEXT_WIDTH,
+      },
+    );
+  });
+
+  it("should rotate, draw rect and stroke, then unrotate", () => {
+    const mockStruct = mockPdfKitDocumentStructure();
+    const mockDoc = mockPdfKitDocument(mockStruct);
+
+    createStamp(mockDoc, mockStruct, false);
+
+    expect(mockDoc.rotate).toHaveBeenCalledWith(-90, {
+      origin: [55, 770],
+    });
+    expect(mockDoc.rect).toHaveBeenCalledWith(40, 750, STAMP_TEXT_WIDTH, 20);
+    expect(mockDoc.stroke).toHaveBeenCalled();
+    expect(mockDoc.rotate).toHaveBeenCalledWith(90, {
+      origin: [55, 770],
+    });
   });
 });

--- a/app/services/pdf/footer/createFooter.ts
+++ b/app/services/pdf/footer/createFooter.ts
@@ -8,12 +8,23 @@ export const createFooter = (
   prefixPageNumber: string,
 ) => {
   const pages = doc.bufferedPageRange();
-  for (let i = 0; i < pages.count; i++) {
-    const footerSect = doc.struct("Sect");
-    doc.switchToPage(i);
 
-    createStamp(doc, footerSect);
-    createPageNumber(doc, footerSect, i + 1, pages.count, prefixPageNumber);
+  const totalPages = pages.count;
+
+  for (let pageIndex = 0; pageIndex < totalPages; pageIndex++) {
+    doc.switchToPage(pageIndex);
+    const footerSect = doc.struct("Sect");
+
+    const isLastPage = pageIndex === totalPages - 1;
+
+    createStamp(doc, footerSect, isLastPage);
+    createPageNumber(
+      doc,
+      footerSect,
+      pageIndex + 1,
+      totalPages,
+      prefixPageNumber,
+    );
     documentStruct.add(footerSect);
   }
 };

--- a/app/services/pdf/footer/createStamp.ts
+++ b/app/services/pdf/footer/createStamp.ts
@@ -1,4 +1,3 @@
-import type PDFDocument from "pdfkit";
 import {
   FONTS_BUNDESSANS_BOLD,
   PDF_HEIGHT_SEIZE,
@@ -10,25 +9,48 @@ export const STAMP_TEXT =
 export const STAMP_TEXT_WIDTH = 188;
 const STAMP_TEXT_HEIGHT = 20;
 
-export const createStamp = (
-  doc: typeof PDFDocument,
+function drawStampText(doc: PDFKit.PDFDocument) {
+  doc
+    .fontSize(8)
+    .rotate(-90, { origin: [55, 770] })
+    .font(FONTS_BUNDESSANS_BOLD)
+    .text(STAMP_TEXT, STAMP_TEXT_HEIGHT * 2, PDF_HEIGHT_SEIZE - 20, {
+      align: "center",
+      width: STAMP_TEXT_WIDTH,
+      baseline: "middle",
+    })
+    .rotate(90, { origin: [55, 770] });
+}
+
+function drawStampDecoration(doc: PDFKit.PDFDocument) {
+  doc
+    .rotate(-90, { origin: [55, 770] })
+    .rect(STAMP_TEXT_HEIGHT * 2, 750, STAMP_TEXT_WIDTH, STAMP_TEXT_HEIGHT)
+    .stroke()
+    .rotate(90, { origin: [55, 770] });
+}
+
+export function createStamp(
+  doc: PDFKit.PDFDocument,
   footerSect: PDFKit.PDFStructureElement,
-) => {
-  footerSect.add(
-    doc.struct("P", {}, () => {
-      doc
-        .save()
-        .fontSize(8)
-        .rotate(-90, { origin: [55, 770] })
-        .font(FONTS_BUNDESSANS_BOLD)
-        .text(STAMP_TEXT, STAMP_TEXT_HEIGHT * 2, PDF_HEIGHT_SEIZE - 20, {
-          align: "center",
-          width: STAMP_TEXT_WIDTH,
-          baseline: "middle",
-        })
-        .rect(STAMP_TEXT_HEIGHT * 2, 750, STAMP_TEXT_WIDTH, STAMP_TEXT_HEIGHT)
-        .stroke()
-        .restore();
-    }),
-  );
-};
+  isLastPage: boolean,
+) {
+  doc.save();
+
+  doc.markContent("Artifact", { type: "Layout" });
+  drawStampDecoration(doc);
+  doc.endMarkedContent();
+
+  if (isLastPage) {
+    const stampParagraph = doc.struct("P", {}, () => {
+      drawStampText(doc);
+    });
+    footerSect.add(stampParagraph);
+  } else {
+    doc.markContent("Artifact", { type: "Pagination" });
+    drawStampText(doc);
+    doc.endMarkedContent();
+  }
+
+  doc.restore();
+}

--- a/tests/factories/mockPdfKit.ts
+++ b/tests/factories/mockPdfKit.ts
@@ -12,9 +12,11 @@ export const mockPdfKitDocument = (
   },
 ) => {
   return {
+    endMarkedContent: vi.fn().mockReturnThis(),
     text: vi.fn().mockReturnThis(),
     fontSize: vi.fn().mockReturnThis(),
     font: vi.fn().mockReturnThis(),
+    markContent: vi.fn().mockReturnThis(),
     moveDown: vi.fn().mockReturnThis(),
     moveUp: vi.fn().mockReturnThis(),
     list: vi.fn().mockReturnThis(),


### PR DESCRIPTION
#### Special thanks to @judithmh for identifying and reporting this issue.

# Problem
It turns out our footer section was only getting added once—at the very end—instead of being created and attached for each page. In the original code, we accidentally instantiated and added footerSect inside the loop, then moved the final add call outside. As a result, only one footer ever made it into the document, which caused the pagination errors you saw.

```diff
+  const footerSect = doc.struct("Sect");
  for (let pageIndex = 0; pageIndex < totalPages; pageIndex++) {
    doc.switchToPage(pageIndex);
-    const footerSect = doc.struct("Sect");

    const isLastPage = pageIndex === totalPages - 1;

    createStamp(doc, footerSect, isLastPage);
    createPageNumber(
      doc,
      footerSect,
      pageIndex + 1,
      totalPages,
      prefixPageNumber,
    );
-   documentStruct.add(footerSect);
  }
+ documentStruct.add(footerSect);
```

# Proposed changes
Adding a new test to confirm we end up with exactly one footer section per page. This will guard against regressions and ensure each page gets its footer moving forward.

# Test
### Beratungshilfe
<img width="480" alt="Bildschirmfoto 2025-07-25 um 13 57 47" src="https://github.com/user-attachments/assets/bb871e5d-bd35-494b-91b5-a84310bf5add" />
<img width="480" alt="Bildschirmfoto 2025-07-25 um 13 57 43" src="https://github.com/user-attachments/assets/8abbde0e-d5d2-4476-8f46-4e29b6384c17" />
<img width="480" alt="Bildschirmfoto 2025-07-25 um 13 57 40" src="https://github.com/user-attachments/assets/3b7fbb6f-4b54-4198-adb9-175eed2d5ab9" />

### Fluggastrechte
<img width="1228" height="940" alt="Bildschirmfoto 2025-07-24 um 17 01 43" src="https://github.com/user-attachments/assets/740c82b1-97ff-4524-9d63-ee23766351a8" />
<img width="1240" height="953" alt="Bildschirmfoto 2025-07-24 um 17 01 32" src="https://github.com/user-attachments/assets/602f4bdd-247a-4333-8762-28d3f6e3cb2a" />
