### PR TITLE
feat(ZOV): no more vertretbare-gruende-abbruch page

### DIFF
--- a/app/domains/fluggastrechte/vorabcheck/__test__/testCasesFluggastrechteVorabcheck.ts
+++ b/app/domains/fluggastrechte/vorabcheck/__test__/testCasesFluggastrechteVorabcheck.ts
@@ -10,7 +10,10 @@ import { testcasesFluggastrechtOtherErfolgs } from "../__test__/testcasesOtherEr
 import { testCasesFluggastrechteVerspaetetAbbruch } from "../__test__/testcasesVerspaetetAbbruch";
 import { guards } from "../guards";
 import { fluggastrechteVorabcheckXstateConfig } from "../xstateConfig";
-import { testCasesFluggastrechteNichtBefoerderungErfolg } from "./testcasesNichtBefoerderungErfolg";
+import {
+  testCasesFluggastrechteNichtBefoerderungErfolg,
+  testCasesFluggastrechteNichtBefoerderungVertretbareGruende,
+} from "./testcasesNichtBefoerderungErfolg";
 
 const machine: FlowStateMachine = createMachine(
   { ...fluggastrechteVorabcheckXstateConfig, context: {} },
@@ -24,6 +27,7 @@ const testsCases = [
   ...testCasesFluggastrechteErfolgEU,
   ...testCasesFluggastrechteNichtBefoerderungAbbruch,
   ...testCasesFluggastrechteNichtBefoerderungErfolg,
+  ...testCasesFluggastrechteNichtBefoerderungVertretbareGruende,
   ...testcasesFluggastrechtOtherErfolgs,
   ...testCasesFluggastrechteVerspaetetAbbruch,
   ...testCasesFluggastrechteFluggesellschaftAbbruch,

--- a/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungAbbruch.ts
+++ b/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungAbbruch.ts
@@ -26,23 +26,6 @@ export const testCasesFluggastrechteNichtBefoerderungAbbruch = [
   [
     {
       bereich: "nichtbefoerderung",
-      ausgleich: "no",
-      checkin: "yes",
-      vertretbareGruende: "yes",
-    },
-    [
-      "/start",
-      "/bereich",
-      "/ausgleich",
-      "/checkin-nicht-befoerderung",
-      "/vertretbare-gruende",
-      "/vertretbare-gruende-info",
-      "/ergebnis/vertretbare-gruende-abbruch",
-    ],
-  ],
-  [
-    {
-      bereich: "nichtbefoerderung",
       ausgleich: "yes",
       ausgleichAngenommen: "no",
       vertretbareGruende: "no",

--- a/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungErfolg.ts
+++ b/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungErfolg.ts
@@ -60,6 +60,7 @@ export const testCasesFluggastrechteNichtBefoerderungVertretbareGruende = [
       "/checkin-nicht-befoerderung",
       "/vertretbare-gruende",
       "/vertretbare-gruende-info",
+      "/verjaehrung",
     ],
   ],
 ] as const satisfies TestCases<FluggastrechtVorabcheckUserData>;

--- a/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungErfolg.ts
+++ b/app/domains/fluggastrechte/vorabcheck/__test__/testcasesNichtBefoerderungErfolg.ts
@@ -41,3 +41,25 @@ export const testCasesFluggastrechteNichtBefoerderungErfolg = [
     ],
   ],
 ] as const satisfies TestCases<FluggastrechtVorabcheckUserData>;
+
+export const testCasesFluggastrechteNichtBefoerderungVertretbareGruende = [
+  [
+    {
+      bereich: "nichtbefoerderung",
+      ausgleich: "yes",
+      ausgleichAngenommen: "yes",
+      checkin: "yes",
+      vertretbareGruende: "yes",
+    },
+    [
+      "/start",
+      "/bereich",
+      "/ausgleich",
+      "/ausgleich-angenommen",
+      "/ausgleich-angenommen-info",
+      "/checkin-nicht-befoerderung",
+      "/vertretbare-gruende",
+      "/vertretbare-gruende-info",
+    ],
+  ],
+] as const satisfies TestCases<FluggastrechtVorabcheckUserData>;

--- a/app/domains/fluggastrechte/vorabcheck/xstateConfig.ts
+++ b/app/domains/fluggastrechte/vorabcheck/xstateConfig.ts
@@ -243,6 +243,12 @@ export const fluggastrechteVorabcheckXstateConfig = {
               context?.vertretbareGruende === "no",
           },
           {
+            target: "vertretbare-gruende-info",
+            guard: ({ context }) =>
+              context?.bereich === "nichtbefoerderung" &&
+              context?.vertretbareGruende === "yes",
+          },
+          {
             target: "gruende",
             guard: "gruendeNo",
           },
@@ -410,12 +416,7 @@ export const fluggastrechteVorabcheckXstateConfig = {
     "vertretbare-gruende-info": {
       on: {
         BACK: "vertretbare-gruende",
-        SUBMIT: "ergebnis/vertretbare-gruende-abbruch",
-      },
-    },
-    "ergebnis/vertretbare-gruende-abbruch": {
-      on: {
-        BACK: "vertretbare-gruende-info",
+        SUBMIT: "verjaehrung",
       },
     },
     kostenlos: {


### PR DESCRIPTION
### Background:
Given I am on the “Vorab-Check” for case type “Nicht-beförderung”

### Scenario: User selects “Ja” for vertretbare Gründe

- When I answer “Ja” on the “vertretbare Gründe” page `/vorabcheck/vertretbare-gruende`
- Then I am redirected to the “vertretbare Gründe Info” page `/vorabcheck/vertretbare-gruende-info`
- And the old abort page `/vorabcheck/ergebnis/vertretbare-gruende-abbruch` is removed
- And I continue to the “Verjährung” page `/vorabcheck/verjaehrung`

### Scenario: User selects “Nein” for vertretbare Gründe

- When I answer “Nein” on the “vertretbare Gründe” page `/vorabcheck/vertretbare-gruende`
- Then I remain on the normal flow and proceed to the “Verjährung” page `/vorabcheck/verjaehrung`
