### PR TITLE
Bugfix: Use lodash.escapeRegExp for safer regex escaping

### DIFF
--- a/app/components/inputs/autoSuggestInput/customComponents/FormatOptionLabel.tsx
+++ b/app/components/inputs/autoSuggestInput/customComponents/FormatOptionLabel.tsx
@@ -1,9 +1,6 @@
+import escapeRegExp from "lodash/escapeRegExp";
 import type { FormatOptionLabelMeta } from "react-select";
 import type { DataListOptions } from "~/services/dataListOptions/getDataListOptions";
-
-function escapeParentheses(string: string) {
-  return string.replace(/[\\()]/g, "\\$&");
-}
 
 function splitHighlightWord(
   text: string | undefined,
@@ -13,7 +10,7 @@ function splitHighlightWord(
     return [];
   }
 
-  return text.split(new RegExp(`(${escapeParentheses(matchWord)})`, "gi"));
+  return text.split(new RegExp(`(${escapeRegExp(matchWord)})`, "gi"));
 }
 
 const renderHighlightText = (

--- a/app/components/inputs/autoSuggestInput/customComponents/__test__/FormatOptionLabel.test.tsx
+++ b/app/components/inputs/autoSuggestInput/customComponents/__test__/FormatOptionLabel.test.tsx
@@ -109,38 +109,28 @@ describe("FormatOptionLabel", () => {
 
   describe("handling special characters in search input", () => {
     const testCases = [
-      {
-        label: "Berlin (BER)",
-        input: "Berlin (BER)",
-      },
-      {
-        label: "Frankfurt (FRA)",
-        input: "(FRA)",
-      },
-      {
-        label: "Munich (MUC) Airport",
-        input: "(MUC)",
-      },
-      {
-        label: "Test Airport (XYZ)",
-        input: "Test Airport (",
-      },
-      {
-        label: "Test ((Double))",
-        input: "((Double))",
-      },
-      {
-        label: "Test\\Backslash",
-        input: "Test\\Backslash",
-      },
-      {
-        label: "Multiple\\\\Backslashes",
-        input: "Multiple\\\\",
-      },
-      {
-        label: "Mixed (Test)\\Case",
-        input: "(Test)\\Case",
-      },
+      { label: "Berlin (BER)", input: "Berlin (BER)" },
+      { label: "Frankfurt (FRA)", input: "(FRA)" },
+      { label: "Munich (MUC) Airport", input: "(MUC)" },
+      { label: "Test Airport (XYZ)", input: "Test Airport (" },
+      { label: "Test ((Double))", input: "((Double))" },
+      { label: "Test\\Backslash", input: "Test\\Backslash" },
+      { label: "Multiple\\\\Backslashes", input: "Multiple\\\\" },
+      { label: "Mixed (Test)\\Case", input: "(Test)\\Case" },
+      { label: "Dot . character", input: "." },
+      { label: "Caret ^ symbol", input: "^" },
+      { label: "Dollar $ sign", input: "$" },
+      { label: "Star * wildcard", input: "*" },
+      { label: "Plus + symbol", input: "+" },
+      { label: "Question mark ?", input: "?" },
+      { label: "Opening ( parenthesis", input: "(" },
+      { label: "Closing ) parenthesis", input: ")" },
+      { label: "Opening [ bracket", input: "[" },
+      { label: "Closing ] bracket", input: "]" },
+      { label: "Opening { brace", input: "{" },
+      { label: "Closing } brace", input: "}" },
+      { label: "Backslash \\ character", input: "\\" },
+      { label: "Pipe | symbol", input: "|" },
     ];
 
     testCases.forEach(({ label, input }) => {

--- a/app/components/inputs/autoSuggestInput/customComponents/__test__/FormatOptionLabel.test.tsx
+++ b/app/components/inputs/autoSuggestInput/customComponents/__test__/FormatOptionLabel.test.tsx
@@ -131,6 +131,11 @@ describe("FormatOptionLabel", () => {
       { label: "Closing } brace", input: "}" },
       { label: "Backslash \\ character", input: "\\" },
       { label: "Pipe | symbol", input: "|" },
+      { label: "Combo: .*+?", input: ".*+?" },
+      { label: "Combo: ^$()[]{}", input: "^$()[]{}" },
+      { label: "Combo: \\.*+?(){}", input: "\\.*+?(){}" },
+      { label: "Combo: ((Test)[1-2]{3})", input: "((Test)[1-2]{3})" },
+      { label: "Combo: |foo|bar|baz", input: "|foo|bar|baz" },
     ];
 
     testCases.forEach(({ label, input }) => {


### PR DESCRIPTION
## Problem
We only escape parentheses, which break whenever someone types `?`, `+`, `.` or any other regex special character. 

## Proposed changes
- Added `lodash.escapeRegExp` to escape all regex-meta chars.
- Updated splitHighlightWord to use it instead of our old helper.
- Expanded test suite with other special characters