### PR TITLE
improve vertical space calculation for claim pdf

### DIFF
--- a/app/domains/fluggastrechte/services/pdf/sections/reason/addNewPageInCaseMissingVerticalSpace.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/addNewPageInCaseMissingVerticalSpace.ts
@@ -1,13 +1,31 @@
 import type PDFDocument from "pdfkit";
 import { PDF_HEIGHT_SEIZE } from "~/services/pdf/createPdfKitDocument";
 
-const MAX_VERTICAL_SPACE = PDF_HEIGHT_SEIZE - 80;
+const MAX_VERTICAL_SPACE = PDF_HEIGHT_SEIZE - 70;
+//doc.moveDown(1) is 20px
+const DEFAULT_MOVE_DOWN = 20;
+
+type AddNewPageInCaseMissingVerticalSpaceParams = {
+  extraYPosition?: number;
+  moveDownFactor?: number;
+  numberOfParagraphs?: number;
+};
 
 export const addNewPageInCaseMissingVerticalSpace = (
   doc: typeof PDFDocument,
-  extraYPosition = 0,
+  {
+    extraYPosition = 0,
+    moveDownFactor = 0,
+    numberOfParagraphs = 0,
+  }: AddNewPageInCaseMissingVerticalSpaceParams,
 ): void => {
-  if (doc.y + extraYPosition >= MAX_VERTICAL_SPACE) {
+  if (
+    doc.y +
+      extraYPosition +
+      //doc.moveDown(x) and paragraphs create vertical space
+      (moveDownFactor + numberOfParagraphs) * DEFAULT_MOVE_DOWN >=
+    MAX_VERTICAL_SPACE
+  ) {
     doc.addPage();
   }
 };

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/createReasonPage.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/createReasonPage.ts
@@ -38,7 +38,9 @@ export const createReasonPage = (
 
   createFactsOfCases(doc, reasonSect, documentStruct, userData);
 
-  addNewPageInCaseMissingVerticalSpace(doc, COLUMN_HEIGHT * 4 + MARGIN_BOTTOM);
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: COLUMN_HEIGHT * 4 + MARGIN_BOTTOM,
+  });
   const startTableY = doc.y;
   addTable(doc, documentStruct, startTableY, userData);
   addCompensationAmount(doc, documentStruct, userData);

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addCompensationAmount.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addCompensationAmount.ts
@@ -7,6 +7,7 @@ import { addMultiplePersonsInfo } from "./addMultiplePersonsInfo";
 import { addOtherDetailsItinerary } from "./addOtherDetailsItinerary";
 import { addWitnessesInfo } from "./addWitnessesInfo";
 import { addNewPageInCaseMissingVerticalSpace } from "../../addNewPageInCaseMissingVerticalSpace";
+import { getHeightOfString } from "../../getHeightOfString";
 
 const COMPENSATION_PAYMENT_TEXT =
   "gemäß Art. 7 der Fluggastrechteverordnung (EG) 261/2004 von der beklagten Partei mit einer hinreichenden Frist von mindestens 2 Wochen ein. Die beklagte Partei hat jedoch trotz Fristablauf bisher keine Zahlung geleistet.";
@@ -27,17 +28,15 @@ export const addCompensationAmount = (
       ? DEMANDED_COMPENSATION_PAYMENT_TEXT
       : OTHER_PASSENGERS_DEMANDED_COMPENSATION_PAYMENT_TEXT;
 
-  const demandedCompensationPaymentTextHeight = doc.heightOfString(
+  const demandedCompensationPaymentTextHeight = getHeightOfString(
     demandedCompensationPaymentText,
-    {
-      width: PDF_WIDTH_SEIZE,
-    },
+    doc,
+    PDF_WIDTH_SEIZE,
   );
 
-  addNewPageInCaseMissingVerticalSpace(
-    doc,
-    demandedCompensationPaymentTextHeight,
-  );
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: demandedCompensationPaymentTextHeight,
+  });
 
   const compensationSect = doc.struct("Sect");
   compensationSect.add(

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addDistanceInfo.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addDistanceInfo.ts
@@ -10,6 +10,7 @@ import {
   PDF_WIDTH_SEIZE,
 } from "~/services/pdf/createPdfKitDocument";
 import { addNewPageInCaseMissingVerticalSpace } from "../../addNewPageInCaseMissingVerticalSpace";
+import { getHeightOfString } from "../../getHeightOfString";
 
 export const ARTICLE_AIR_PASSENGER_REGULATION_TEXT =
   "Damit ergibt sich nach Art. 7 der Fluggastrechteverordnung (EG) 261/2004 eine Entschädigung in Höhe von";
@@ -49,11 +50,15 @@ export const addDistanceInfo = (
 ) => {
   const distanceText = getDistanceText(userData);
 
-  const distanceTextHeight = doc.heightOfString(distanceText, {
-    width: PDF_WIDTH_SEIZE,
-  });
+  const distanceTextHeight = getHeightOfString(
+    distanceText,
+    doc,
+    PDF_WIDTH_SEIZE,
+  );
 
-  addNewPageInCaseMissingVerticalSpace(doc, distanceTextHeight);
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: distanceTextHeight,
+  });
   const distanceSect = doc.struct("Sect");
   distanceSect.add(
     doc.struct("P", {}, () => {

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addMultiplePersonsInfo.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addMultiplePersonsInfo.ts
@@ -37,7 +37,7 @@ export const addMultiplePersonsInfo = (
     return;
   }
 
-  addNewPageInCaseMissingVerticalSpace(doc);
+  addNewPageInCaseMissingVerticalSpace(doc, {});
 
   const personsNames = weiterePersonen
     .flatMap(({ anrede, title, nachname, vorname }) => {
@@ -56,7 +56,7 @@ export const addMultiplePersonsInfo = (
     }),
   );
 
-  addNewPageInCaseMissingVerticalSpace(doc);
+  addNewPageInCaseMissingVerticalSpace(doc, {});
 
   if (hasZeugen === "yes") {
     compensationSect.add(

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addOtherDetailsItinerary.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addOtherDetailsItinerary.ts
@@ -6,6 +6,7 @@ import {
   PDF_WIDTH_SEIZE,
 } from "~/services/pdf/createPdfKitDocument";
 import { addNewPageInCaseMissingVerticalSpace } from "../../addNewPageInCaseMissingVerticalSpace";
+import { getHeightOfString } from "../../getHeightOfString";
 
 export const OTHER_DETAILS_ITINERARY = "Weitere Angaben zum Reiseverlauf:";
 
@@ -18,21 +19,15 @@ export const addOtherDetailsItinerary = (
     typeof zusaetzlicheAngaben !== "undefined" &&
     zusaetzlicheAngaben.length > 0
   ) {
-    const otherDetailsItineraryHeight = doc.heightOfString(
-      OTHER_DETAILS_ITINERARY,
-      {
-        width: PDF_WIDTH_SEIZE,
-      },
-    );
-
-    const zusaetzlicheAngabenHeight = doc.heightOfString(zusaetzlicheAngaben, {
-      width: PDF_WIDTH_SEIZE,
-    });
-
-    addNewPageInCaseMissingVerticalSpace(
+    const totalHeightOfStrings = getHeightOfString(
+      [OTHER_DETAILS_ITINERARY, zusaetzlicheAngaben],
       doc,
-      zusaetzlicheAngabenHeight + otherDetailsItineraryHeight,
+      PDF_WIDTH_SEIZE,
     );
+
+    addNewPageInCaseMissingVerticalSpace(doc, {
+      extraYPosition: totalHeightOfStrings,
+    });
 
     const compensationSect = doc.struct("Sect");
     compensationSect.add(

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addWitnessesInfo.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/compensationAmount/addWitnessesInfo.ts
@@ -15,7 +15,7 @@ export const addWitnessesInfo = (
   compensationSect: PDFKit.PDFStructureElement,
 ) => {
   if (hasZeugen === "yes") {
-    addNewPageInCaseMissingVerticalSpace(doc);
+    addNewPageInCaseMissingVerticalSpace(doc, {});
     compensationSect.add(
       doc.struct("P", {}, () => {
         doc.text(

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/table/addTableInfo.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/factsOfCases/table/addTableInfo.ts
@@ -5,6 +5,7 @@ import {
   PDF_WIDTH_SEIZE,
 } from "~/services/pdf/createPdfKitDocument";
 import { addNewPageInCaseMissingVerticalSpace } from "../../addNewPageInCaseMissingVerticalSpace";
+import { getHeightOfString } from "../../getHeightOfString";
 
 export const HEADLINE = "Beschreibung der Ersatzverbindung:";
 
@@ -17,21 +18,15 @@ export function addTableInfo(
     return;
   }
 
-  const tableInfoHeight = doc.heightOfString(
-    andereErsatzverbindungBeschreibung,
-    {
-      width: PDF_WIDTH_SEIZE,
-    },
-  );
-
-  const tableInfoHeadline = doc.heightOfString(HEADLINE, {
-    width: PDF_WIDTH_SEIZE,
-  });
-
-  addNewPageInCaseMissingVerticalSpace(
+  const tableInfoTextHeight = getHeightOfString(
+    [andereErsatzverbindungBeschreibung, HEADLINE],
     doc,
-    tableInfoHeight + tableInfoHeadline,
+    PDF_WIDTH_SEIZE,
   );
+
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: tableInfoTextHeight,
+  });
 
   const reasonSect = doc.struct("Sect");
   reasonSect.add(

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/getHeightOfString.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/getHeightOfString.ts
@@ -1,0 +1,16 @@
+import type PDFDocument from "pdfkit";
+
+export const getHeightOfString = (
+  text: string | string[],
+  doc: typeof PDFDocument,
+  width: number,
+): number => {
+  if (typeof text === "string") {
+    return doc.heightOfString(text, { width });
+  }
+
+  return text.reduce(
+    (acc, part) => acc + doc.heightOfString(part, { width }),
+    0,
+  );
+};

--- a/app/domains/fluggastrechte/services/pdf/sections/reason/legalAssessment/createLegalAssessment.ts
+++ b/app/domains/fluggastrechte/services/pdf/sections/reason/legalAssessment/createLegalAssessment.ts
@@ -11,6 +11,7 @@ import {
 import { MARGIN_BETWEEN_SECTIONS } from "../../../configurations";
 import { getFullPlaintiffName } from "../../getFullPlaintiffName";
 import { addNewPageInCaseMissingVerticalSpace } from "../addNewPageInCaseMissingVerticalSpace";
+import { getHeightOfString } from "../getHeightOfString";
 
 export const LEGAL_ASSESSMENT_TEXT = "II. Rechtliche Würdigung";
 export const CLAIM_FULL_JUSTIFIED_TEXT =
@@ -43,30 +44,19 @@ function checkAndNewPage(
   doc: typeof PDFDocument,
   assumedSettlementSectionText: string,
 ) {
-  const legalAssessmentHeight = doc.heightOfString(LEGAL_ASSESSMENT_TEXT, {
-    width: PDF_WIDTH_SEIZE,
-  });
-
-  const claimFullJustifiedTextHeight = doc.heightOfString(
-    CLAIM_FULL_JUSTIFIED_TEXT,
-    {
-      width: PDF_WIDTH_SEIZE,
-    },
-  );
-
-  const assumedSettlementSectionTextHeight = doc.heightOfString(
-    assumedSettlementSectionText,
-    {
-      width: PDF_WIDTH_SEIZE,
-    },
-  );
-
-  addNewPageInCaseMissingVerticalSpace(
+  const legalAssessmentTextsHeight = getHeightOfString(
+    [
+      LEGAL_ASSESSMENT_TEXT,
+      CLAIM_FULL_JUSTIFIED_TEXT,
+      assumedSettlementSectionText,
+    ],
     doc,
-    legalAssessmentHeight +
-      claimFullJustifiedTextHeight +
-      assumedSettlementSectionTextHeight,
+    PDF_WIDTH_SEIZE,
   );
+
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: legalAssessmentTextsHeight,
+  });
 }
 
 export const createLegalAssessment = (
@@ -121,10 +111,11 @@ export const createLegalAssessment = (
     width: PDF_WIDTH_SEIZE,
   });
   // avoid that a new page consits only of the plaintiff name
-  addNewPageInCaseMissingVerticalSpace(
-    doc,
-    advanceCourtTextHeight + plaintiffNameTextHeight + MARGIN_BETWEEN_SECTIONS,
-  );
+  addNewPageInCaseMissingVerticalSpace(doc, {
+    extraYPosition: advanceCourtTextHeight + plaintiffNameTextHeight,
+    moveDownFactor: MARGIN_BETWEEN_SECTIONS,
+    numberOfParagraphs: 2,
+  });
   legalAssessmentSect.add(
     doc.struct("P", {}, () => {
       doc.text(advanceCourtText);


### PR DESCRIPTION
- function to measure height of strings is an extra function now and several strings can be passed (readability of code)
- fixes issue of vertical space calculation when a lot of text was entered in Beschreibung der Ersatzverbindung und 
Weitere Angaben zum Reiseverlauf

<img width="739" height="292" alt="Screenshot 2025-08-14 at 15 47 26" src="https://github.com/user-attachments/assets/812e1099-8429-462b-a817-7aa4ab4093b8" />
