### PR TITLE
feat(StrapiImage): fetch svg on transform & inline

### DIFF
--- a/app/components/common/Image.tsx
+++ b/app/components/common/Image.tsx
@@ -1,5 +1,4 @@
-import Svg from "react-inlinesvg";
-import { useJsAvailable } from "../hooks/useJsAvailable";
+import { InlineSvgImage } from "./InlineSvgImage";
 
 export type ImageProps = Readonly<{
   url: string;
@@ -8,52 +7,36 @@ export type ImageProps = Readonly<{
   height?: number;
   alternativeText?: string;
   className?: string;
+  svgString?: string;
 }>;
-
-// Create a constant variable to avoid complains from Sonar
-const SVG_ROLE = "img";
 // An empty alt attribute is needed for accessibility when the image is decorative
 const EMPTY_ALTERNATIVE_TEXT = "";
 
-function Image({ url, ariaHidden, alternativeText, ...props }: ImageProps) {
-  const jsAvailable = useJsAvailable();
-
-  const isSvg = url.endsWith(".svg");
+function Image({
+  url,
+  ariaHidden,
+  alternativeText,
+  svgString,
+  ...props
+}: ImageProps) {
   const altText = alternativeText ?? EMPTY_ALTERNATIVE_TEXT;
 
-  const ImageComponent = (
+  if (svgString)
+    return (
+      <InlineSvgImage
+        svgString={svgString}
+        width={props.width ?? 0}
+        altText={altText}
+      />
+    );
+
+  return (
     <img
       {...props}
       src={url}
       alt={altText}
       title={altText}
       aria-hidden={ariaHidden}
-    />
-  );
-
-  if (!isSvg) {
-    return ImageComponent;
-  }
-
-  if (!jsAvailable) {
-    /**
-     * <noscript> tag prevents that <img> is cached by the browser when js is available
-     * more details here: https://github.com/tanem/react-svg/issues/197 and https://serverfault.com/a/856948
-     */
-    return <noscript>{ImageComponent}</noscript>;
-  }
-  return (
-    <Svg
-      {...props}
-      /* This class ensures black SVG paths don't disappear in high-contrast mode. 
-        For implementation details check app/styles.css */
-      className="svg-image"
-      src={url}
-      title={altText}
-      role={SVG_ROLE}
-      // If the alt text is empty, the image is decorative, so we set aria-hidden to true
-      aria-hidden={altText === EMPTY_ALTERNATIVE_TEXT ? true : ariaHidden}
-      height="100%"
     />
   );
 }

--- a/app/components/common/InlineSvgImage.tsx
+++ b/app/components/common/InlineSvgImage.tsx
@@ -1,0 +1,30 @@
+type InlineSvgProps = {
+  svgString: string;
+  width: number;
+  altText: string;
+};
+
+export const InlineSvgImage = ({
+  svgString,
+  width,
+  altText,
+}: InlineSvgProps) => {
+  let svgElementString = svgString.slice(svgString.search("<svg")); // drop anything before opening tag <svg
+
+  const replacements = [
+    [">", ` class="svg-image">`], // Ensure black SVG paths don't disappear in high-contrast mode. For implementation details check app/styles.css
+    [">", ` role="img">`],
+    ["height", `originalHeight`],
+    ["width", `originalWidth`],
+    // [">", ` height="100%">`],
+    [">", ` width="${width}">`],
+    altText && [">", `><title>${altText}</title>`],
+    [">", ` aria-hidden='${!!altText}'>`], // If the alt text is empty, the image is decorative, so we set aria-hidden to true
+  ] as const;
+
+  replacements.forEach(([search, replace]) => {
+    svgElementString = svgElementString.replace(search, replace);
+  });
+
+  return <div dangerouslySetInnerHTML={{ __html: svgElementString }} />;
+};

--- a/app/components/common/__test__/Image.test.tsx
+++ b/app/components/common/__test__/Image.test.tsx
@@ -14,24 +14,12 @@ describe("Image", () => {
   });
 
   it("should render an svg image inline instead of as an <img> tag", async () => {
-    const { queryByRole } = await act(() =>
-      render(<Image url="image.svg" alternativeText={altText} />),
+    const { getByTitle } = await act(() =>
+      render(
+        <Image url="a.svg" svgString="<svg></svg>" alternativeText={altText} />,
+      ),
     );
-    // since react-inlinesvg parses an actual svg to create the DOM,
-    // we basically just need to ensure that an <img> isn't present
-    expect(queryByRole("img")).not.toBeInTheDocument();
-  });
-
-  it("should render a noscript without JS", async () => {
-    vi.mock(import("react"), async (importOriginal) => ({
-      ...(await importOriginal()),
-      useState: vi.fn().mockReturnValue([false, vi.fn()]),
-    }));
-
-    const { baseElement } = await act(() =>
-      render(<Image url="image.svg" alternativeText={altText} />),
-    );
-    expect(baseElement).toContainHTML("<noscript>");
+    expect(getByTitle(altText).parentElement?.tagName).toBe("svg");
   });
 
   it("should render an image as with aria-hidden as true", () => {

--- a/app/services/cms/__test__/index.test.ts
+++ b/app/services/cms/__test__/index.test.ts
@@ -23,7 +23,7 @@ describe("services/cms", () => {
       const footerData = getStrapiFooter();
       vi.mocked(getStrapiEntry).mockReturnValue(Promise.resolve([footerData]));
       expect(await fetchSingleEntry("footer")).toEqual(
-        StrapiFooterSchema.parse(footerData),
+        await StrapiFooterSchema.parseAsync(footerData),
       );
     });
   });

--- a/app/services/cms/index.server.ts
+++ b/app/services/cms/index.server.ts
@@ -44,7 +44,7 @@ export async function fetchSingleEntry<T extends SingleEntryId>(
   pLevel = P_LEVEL_DEFAULT,
 ): Promise<StrapiSchemasOutput[T][number]> {
   const strapiEntry = await getStrapiEntry({ apiId, locale, pLevel });
-  return entrySchemas[apiId].parse(strapiEntry)[0];
+  return (await entrySchemas[apiId].parseAsync(strapiEntry))[0];
 }
 
 async function fetchCollectionEntry<T extends CollectionId>(
@@ -54,7 +54,8 @@ async function fetchCollectionEntry<T extends CollectionId>(
   locale?: StrapiLocale,
 ): Promise<StrapiSchemasOutput[T][number]> {
   const strapiEntry = await getStrapiEntry({ apiId, filters, locale, pLevel });
-  const strapiEntryParsed = collectionSchemas[apiId].safeParse(strapiEntry);
+  const strapiEntryParsed =
+    await collectionSchemas[apiId].safeParseAsync(strapiEntry);
 
   if (strapiEntryParsed?.data?.length === 0) {
     const error = new Error(

--- a/app/services/cms/models/StrapiImage.ts
+++ b/app/services/cms/models/StrapiImage.ts
@@ -16,12 +16,19 @@ function appendStrapiUrlOnDev(imageUrl: string) {
   return strapiUrl + imageUrl;
 }
 
-export const StrapiImageSchema = z.object({
-  url: z.string().transform(appendStrapiUrlOnDev),
-  width: z.number(),
-  height: z.number(),
-  alternativeText: StrapiStringOptionalSchema,
-});
+export const StrapiImageSchema = z
+  .object({
+    url: z.string().transform(appendStrapiUrlOnDev),
+    width: z.number(),
+    height: z.number(),
+    alternativeText: StrapiStringOptionalSchema,
+  })
+  .transform(async (cmsImage) => {
+    if (!cmsImage.url.endsWith(".svg")) return cmsImage;
+    // Note: this is mixing data validation / transformation with enriching
+    // We should find a more idiomatic way for this in the future
+    return { ...cmsImage, svgString: await (await fetch(cmsImage.url)).text() };
+  });
 
 export const StrapiImageOptionalSchema = StrapiImageSchema.nullable()
   .transform(omitNull)

--- a/app/services/cms/models/__test__/StrapiFooter.test.ts
+++ b/app/services/cms/models/__test__/StrapiFooter.test.ts
@@ -3,32 +3,34 @@ import { getStrapiFooter } from "tests/factories/cmsModels/strapiFooter";
 import { StrapiFooterSchema } from "../StrapiFooter";
 
 describe("StrapiFooterSchema", () => {
-  it("should validate correct footer data", () => {
-    const result = StrapiFooterSchema.safeParse(getStrapiFooter());
+  it("should validate correct footer data", async () => {
+    const result = await StrapiFooterSchema.safeParseAsync(getStrapiFooter());
     expect(result.success).toBe(true);
     expect(result.success && result.data).not.toHaveProperty("locale");
   });
 
-  it("should allow footer without image", () => {
+  it("should allow footer without image", async () => {
     const dataWithoutImage = {
       ...getStrapiFooter(),
       image: null,
     };
-    const result = StrapiFooterSchema.safeParse(dataWithoutImage);
+    const result = await StrapiFooterSchema.safeParseAsync(dataWithoutImage);
     expect(result.success).toBe(true);
     expect(result.success && result.data.image).toBeUndefined();
   });
 
-  it("should require non-empty categorizedLinks array", () => {
+  it("should require non-empty categorizedLinks array", async () => {
     const dataWithEmptyCategories = {
       ...getStrapiFooter(),
       categorizedLinks: [],
     };
-    const result = StrapiFooterSchema.safeParse(dataWithEmptyCategories);
+    const result = await StrapiFooterSchema.safeParseAsync(
+      dataWithEmptyCategories,
+    );
     expect(result.success).toBe(false);
   });
 
-  it("should require non-empty links array in categories", () => {
+  it("should require non-empty links array in categories", async () => {
     const dataWithEmptyLinks = {
       ...getStrapiFooter(),
       categorizedLinks: [
@@ -40,11 +42,11 @@ describe("StrapiFooterSchema", () => {
         },
       ],
     };
-    const result = StrapiFooterSchema.safeParse(dataWithEmptyLinks);
+    const result = await StrapiFooterSchema.safeParseAsync(dataWithEmptyLinks);
     expect(result.success).toBe(false);
   });
 
-  it("should require non-empty category title", () => {
+  it("should require non-empty category title", async () => {
     const dataWithEmptyTitle = {
       ...getStrapiFooter(),
       categorizedLinks: [
@@ -63,7 +65,7 @@ describe("StrapiFooterSchema", () => {
         },
       ],
     };
-    const result = StrapiFooterSchema.safeParse(dataWithEmptyTitle);
+    const result = await StrapiFooterSchema.safeParseAsync(dataWithEmptyTitle);
     expect(result.success).toBe(false);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react-collapsed": "^4.2.0",
         "react-dom": "^19.1.1",
         "react-imask": "^7.6.1",
-        "react-inlinesvg": "^4.2.0",
         "react-router": "^7.8.2",
         "react-select": "^5.10.2",
         "samlify": "github:digitalservicebund/samlify#19b7a2e03a1ce99953b32f909bc219acd4d454ec",
@@ -13739,15 +13738,6 @@
         "react": "^19.1.1"
       }
     },
-    "node_modules/react-from-dom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.7.5.tgz",
-      "integrity": "sha512-CO92PmMKo/23uYPm6OFvh5CtZbMgHs/Xn+o095Lz/TZj9t8DSDhGdSOMLxBxwWI4sr0MF17KUn9yJWc5Q00R/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "16.8 - 19"
-      }
-    },
     "node_modules/react-imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
@@ -13762,18 +13752,6 @@
       },
       "peerDependencies": {
         "react": ">=0.14.0"
-      }
-    },
-    "node_modules/react-inlinesvg": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-4.2.0.tgz",
-      "integrity": "sha512-V59P6sFU7NACIbvoay9ikYKVFWyIIZFGd7w6YT1m+H7Ues0fOI6B6IftE6NPSYXXv7RHVmrncIyJeYurs3OJcA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-from-dom": "^0.7.5"
-      },
-      "peerDependencies": {
-        "react": "16.8 - 19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-collapsed": "^4.2.0",
     "react-dom": "^19.1.1",
     "react-imask": "^7.6.1",
-    "react-inlinesvg": "^4.2.0",
     "react-router": "^7.8.2",
     "react-select": "^5.10.2",
     "samlify": "github:digitalservicebund/samlify#19b7a2e03a1ce99953b32f909bc219acd4d454ec",

--- a/tests/factories/cmsModels/strapiImage.ts
+++ b/tests/factories/cmsModels/strapiImage.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker";
 export function getStrapiImage() {
   const name = faker.string.alphanumeric({ length: 5 });
   const hash = faker.string.alphanumeric({ length: 10 });
-  const ext = faker.helpers.arrayElement(["png", "jpg", "svg", "gif"]);
+  const ext = faker.helpers.arrayElement(["png", "jpg", "gif"]); // svg would cause a fetch to facilitate inlining
 
   return {
     name: `${name}.${ext}`,


### PR DESCRIPTION
This is experimental for two reasons:
- mixing data transformation with enriching (fetching svg images in the `StrapiImage` schema)
- string editing & `dangerouslySetInnerHTML` inside `InlineSvgImage`
- all parses now have to be run async (although that was surprisingly little pain)
 
On the upside, SVGs are now inline on the server without any client JS. No more layout shift & late pop-ins (plus one less dependency!)