### PR TITLE
refactor(autocomplete): remove attribute from customInput

### DIFF
--- a/app/components/formElements/autoSuggestInput/customComponents/CustomInput.tsx
+++ b/app/components/formElements/autoSuggestInput/customComponents/CustomInput.tsx
@@ -7,7 +7,6 @@ import {
 } from "react-select";
 import type { DataListOptions } from "~/services/dataListOptions/getDataListOptions";
 import { INPUT_CHAR_LIMIT } from "~/services/validation/inputlimits";
-import { autocompleteMap } from "~/util/autocompleteMap";
 
 //Will become obsolete with the next version bump: https://github.com/JedWatson/react-select/pull/6016
 type CustomSelectProps = Props<
@@ -37,7 +36,6 @@ const CustomInput = (props: InputProps<DataListOptions, false>) => {
       aria-required={props.selectProps.className?.includes(
         "auto-suggest-input-required",
       )}
-      autoComplete={autocompleteMap[field.name()] ?? "off"}
     />
   );
 };

--- a/app/util/autocompleteMap.ts
+++ b/app/util/autocompleteMap.ts
@@ -1,7 +1,6 @@
 export const autocompleteMap: Record<string, string> = {
   vorname: "given-name",
   nachname: "family-name",
-  street: "address-line1",
   houseNumber: "address-line2",
   ort: "address-level2",
   plz: "postal-code",


### PR DESCRIPTION
This PR removes autocomplete from customInput and street attribute from the map to don't interfere in the autosuggest