### PR TITLE
bug(KP Wegweiser): fix string replacement for arbeitsentgeltEinmalig

### DIFF
--- a/app/domains/kontopfaendung/wegweiser/stringReplacements.ts
+++ b/app/domains/kontopfaendung/wegweiser/stringReplacements.ts
@@ -128,9 +128,11 @@ export const getArbeitsentgeltEinmaligStrings = (
   return {
     hasArbeitsentgeltEinmalig:
       !!userData.zahlungArbeitgeber &&
-      Object.values(userData.zahlungArbeitgeber).some(
-        (value) => value === "on",
-      ),
+      (userData.zahlungArbeitgeber?.urlaubsgeld === "on" ||
+        userData.zahlungArbeitgeber?.weihnachtsgeld === "on" ||
+        userData.zahlungArbeitgeber?.ueberstundenBezahlt === "on" ||
+        userData.zahlungArbeitgeber?.abfindung === "on" ||
+        userData.zahlungArbeitgeber?.anderes === "on"),
   };
 };
 export const getSelbststaendigStrings = (


### PR DESCRIPTION
This PR removes the none option from arbeitsentgeltEinmalig string replacement