### PR TITLE
refactor(Zod Integers): Transform integers back into strings after manipulation

### DIFF
--- a/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
+++ b/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
@@ -56,7 +56,7 @@ describe("ValidatedFlowForm", () => {
       );
     });
     const { component, expectInputErrorToExist } = getStrapiInputComponent({
-      code: "invalidNumber",
+      code: "invalidInteger",
       text: "Please enter a valid integer.",
     });
 

--- a/app/services/validation/__test__/integer.test.ts
+++ b/app/services/validation/__test__/integer.test.ts
@@ -5,7 +5,11 @@ describe("integer", () => {
     const cases = [
       { input: " 100  ", expected: 100 },
       { input: "1000", expected: 1000 },
-      { input: "1000.0", expected: 1000 },
+      { input: "1.000", expected: 1000 },
+      { input: "1.000.000", expected: 1000000 },
+      { input: "1000,9", expected: 1001 },
+      { input: "1.000.000,1", expected: 1000000 },
+      { input: 1000, expected: 1000 },
     ];
 
     test.each(cases)(
@@ -22,10 +26,11 @@ describe("integer", () => {
       { input: "", errorMessage: "required" },
       { input: "    ", errorMessage: "required" },
       { input: "10a", errorMessage: "invalidNumber" },
-      { input: "1.000.000", errorMessage: "invalidNumber" },
-      { input: "1000,9", errorMessage: "invalidNumber" },
-      { input: "1.000.000,1", errorMessage: "invalidNumber" },
-      { input: "1.057", errorMessage: "invalidInteger" },
+      { input: "1.0", errorMessage: "invalidInteger" },
+      { input: "1000.0", errorMessage: "invalidInteger" },
+      { input: "1000,0,", errorMessage: "invalidInteger" },
+      { input: "100.0,", errorMessage: "invalidInteger" },
+      { input: 10.24, errorMessage: "invalidInteger" },
     ];
 
     test.each(cases)(

--- a/app/services/validation/integer.ts
+++ b/app/services/validation/integer.ts
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
 export const integerSchema = z.coerce
-  .number({
+  .string()
+  .trim()
+  .min(1, { message: "required" })
+  .refine((numString) => /^[\d.,]*$/.test(numString), {
     message: "invalidNumber",
   })
-  .refine((number) => number !== 0, {
-    message: "required",
-  })
-  .refine((number) => Number.isInteger(number), {
-    message: "invalidInteger",
-  });
+  .refine(
+    (numString) => /^-?(\d+|\d{1,3}(\.\d{3})+)(,(\s)?\d*)?$/.test(numString),
+    {
+      message: "invalidInteger",
+    },
+  )
+  .transform((numString) =>
+    Math.round(Number(numString.replace(/\./g, "").replace(",", "."))),
+  );


### PR DESCRIPTION
This PR adds integer coercion to the beginning of our zod integer schema to ensure that integers saved in Redis are parsed/validated correctly.

This hasn't caused issues up until this point because when users input an integer into a field, it gets sent in the formData as a string (and correctly parsed against integerSchema, where the input is a string and the output is an integer). 

Now that we're parsing userData directly against the schema, the integer's input vs output type are misaligned. 
