### PR TITLE
fix(KERN): revert box from link to button

### DIFF
--- a/app/components/kern/KernBox.tsx
+++ b/app/components/kern/KernBox.tsx
@@ -9,8 +9,8 @@ import { GridItem } from "~/components/layout/grid/GridItem";
 import { arrayIsNonEmpty } from "~/util/array";
 import KernLabel, { type KernLabelProps } from "./KernLabel";
 import KernBoxItem, { type KernBoxItemProps } from "./KernBoxItem";
-import { KernIcon } from "./common/KernIcon";
-import { type ButtonProps } from "./KernButton";
+import KernButton, { type ButtonProps } from "./KernButton";
+import ButtonContainer from "../common/ButtonContainer";
 
 type BoxProps = {
   identifier?: string;
@@ -60,18 +60,11 @@ const KernBox = ({
         </div>
       )}
       {arrayIsNonEmpty(buttons) && (
-        <div>
+        <ButtonContainer className="kern-button-group pt-kern-space-x-large">
           {buttons.map((button) => (
-            <a
-              href={button.href}
-              className="kern-link inline-flex items-center! no-underline!"
-              key={button.text ?? button.href}
-            >
-              <KernIcon className="size-[1em]" name="arrow-forward" />
-              {button.text}
-            </a>
+            <KernButton key={button.text ?? button.href} {...button} />
           ))}
-        </div>
+        </ButtonContainer>
       )}
     </div>
   );


### PR DESCRIPTION
This PR revert the previous change from link to button

**Before**

<img width="1164" height="700" alt="Screenshot 2026-04-14 at 08 33 41" src="https://github.com/user-attachments/assets/77dbba0c-7fae-4b9f-9374-8d0b2f820cc2" />

**After**

<img width="847" height="896" alt="Screenshot 2026-04-14 at 08 31 26" src="https://github.com/user-attachments/assets/fde8e58a-fbdc-461c-8cce-a2271a15b9d6" />
