### PR TITLE
refactor(KERN): remove showKernUX from render

### DIFF
--- a/app/components/formElements/SchemaComponents.tsx
+++ b/app/components/formElements/SchemaComponents.tsx
@@ -46,12 +46,7 @@ export const SchemaComponents = ({
         );
 
         if (fieldSetGroup !== undefined) {
-          return renderFieldSet(
-            fieldName,
-            fieldSetGroup,
-            readOnlyFieldNames,
-            false,
-          );
+          return renderFieldSet(fieldName, fieldSetGroup, readOnlyFieldNames);
         }
 
         const isFieldReadOnly = readOnlyFieldNames.includes(fieldName);

--- a/app/components/formElements/__test__/SchemaComponents.test.tsx
+++ b/app/components/formElements/__test__/SchemaComponents.test.tsx
@@ -5,11 +5,11 @@ import {
   checkedRequired,
   exclusiveCheckboxesSchema,
 } from "~/services/validation/checkedCheckbox";
-import { SchemaComponents } from "../SchemaComponents";
 import { hiddenInputSchema } from "~/services/validation/hiddenInput";
 import { type StrapiFormComponent } from "~/services/cms/models/formElements/StrapiFormComponent";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { getPageSchema } from "~/domains/pageSchemas";
+import { KernSchemaComponents } from "~/components/kernFormElements/KernSchemaComponents";
 
 vi.mock("~/domains/pageSchemas");
 
@@ -19,7 +19,7 @@ const mockGetPageSchema = (pageSchema: any) => {
 
 describe("SchemaComponents", () => {
   function WrappedSchemaComponents(
-    props: Readonly<Parameters<typeof SchemaComponents>[0]>,
+    props: Readonly<Parameters<typeof KernSchemaComponents>[0]>,
   ) {
     const form = useForm({
       schema: z.object(props.pageSchema),
@@ -31,7 +31,7 @@ describe("SchemaComponents", () => {
         path: "/",
         element: (
           <FormProvider scope={form.scope()}>
-            <SchemaComponents {...props} />
+            <KernSchemaComponents {...props} />
           </FormProvider>
         ),
       },
@@ -128,11 +128,16 @@ describe("SchemaComponents", () => {
         ]}
       />,
     );
-    const radio = getByRole("radio");
+    const group = getByRole("group");
+    expect(group).toBeInTheDocument();
+    const radio = group.querySelector(
+      'input[type="radio"]',
+    ) as HTMLInputElement;
+    expect(radio).toBeInTheDocument();
     expect(radio).toHaveAttribute("name", "field1");
     expect(radio).toHaveAttribute("value", "option1");
-    expect(radio.parentElement).toHaveTextContent("option1 title");
-    expect(radio.parentElement).toHaveTextContent("option1 description");
+    expect(group).toHaveTextContent("option1 title");
+    expect(group).toHaveTextContent("option1 description");
   });
 
   it("should render checkboxes ", () => {

--- a/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
+++ b/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
@@ -101,7 +101,7 @@ describe("ValidatedFlowForm", () => {
       await waitFor(() => {
         expect(inputComponent).not.toHaveClass("has-error");
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -151,7 +151,7 @@ describe("ValidatedFlowForm", () => {
       await waitFor(() => {
         expect(dateInputComponent).not.toHaveClass("has-error");
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -201,7 +201,7 @@ describe("ValidatedFlowForm", () => {
       await waitFor(() => {
         expect(timeInputComponent).not.toHaveClass("has-error");
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -246,7 +246,7 @@ describe("ValidatedFlowForm", () => {
       await waitFor(() => {
         expect(textareaComponent).not.toHaveClass("has-error");
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -291,7 +291,7 @@ describe("ValidatedFlowForm", () => {
       fireEvent.click(getByText("NEXT"));
       await waitFor(() => {
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -309,11 +309,12 @@ describe("ValidatedFlowForm", () => {
       });
 
     it("should display an error if the user doesn't select an option", async () => {
-      const { getByText, getByRole } = renderValidatedFlowForm([component]);
+      const { getByText, getByTestId } = renderValidatedFlowForm([component]);
 
+      const select = getByTestId("select");
+      fireEvent.change(select, { target: { value: "" } });
       const nextButton = getByText("NEXT");
-      expect(nextButton).toBeInTheDocument();
-      fireEvent.blur(getByRole("option", { name: "Select a value." }));
+      fireEvent.click(nextButton);
       await expectDropdownErrorToExist();
     });
 
@@ -324,7 +325,7 @@ describe("ValidatedFlowForm", () => {
       fireEvent.click(getByText("NEXT"));
       await waitFor(() => {
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -388,7 +389,7 @@ describe("ValidatedFlowForm", () => {
       fireEvent.click(getByText("NEXT"));
       await waitFor(() => {
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
   });
@@ -423,7 +424,7 @@ describe("ValidatedFlowForm", () => {
       fireEvent.click(getByText("NEXT"));
       await waitFor(() => {
         expect(queryByTestId("inputError")).not.toBeInTheDocument();
-        expect(queryByTestId("ErrorOutlineIcon")).not.toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).not.toBeInTheDocument();
       });
     });
 
@@ -432,7 +433,7 @@ describe("ValidatedFlowForm", () => {
         renderValidatedFlowForm([component]);
       fireEvent.click(getByText("NEXT"));
       await waitFor(() => {
-        expect(queryByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(queryByTestId("icon-emergency-home")).toBeInTheDocument();
         const radioButtons = getAllByRole("radio");
         const firstRadio = radioButtons[0];
         const secondRadio = radioButtons[1];

--- a/app/components/formElements/schemaToForm/renderFieldSet.tsx
+++ b/app/components/formElements/schemaToForm/renderFieldSet.tsx
@@ -1,6 +1,5 @@
 import { type StrapiFormComponent } from "~/services/cms/models/formElements/StrapiFormComponent";
 import { type StrapiFieldSet } from "~/services/cms/models/formElements/StrapiFieldSet";
-import { FieldSet } from "../FieldSet";
 import { KernFieldset } from "~/components/kern/formElements/KernFieldset";
 
 export const getFieldSetByFieldName = (
@@ -21,7 +20,6 @@ export const renderFieldSet = (
   fieldName: string,
   fieldSet: StrapiFieldSet,
   readOnlyFieldNames: string[],
-  showKernUX?: boolean,
 ) => {
   const {
     fieldSetGroup: { formComponents },
@@ -35,16 +33,8 @@ export const renderFieldSet = (
     return null;
   }
 
-  return showKernUX ? (
+  return (
     <KernFieldset
-      key={id}
-      formComponents={formComponents}
-      heading={heading}
-      image={image}
-      readOnlyFieldNames={readOnlyFieldNames}
-    />
-  ) : (
-    <FieldSet
       key={id}
       formComponents={formComponents}
       heading={heading}

--- a/app/components/formElements/schemaToForm/renderZodEnum.tsx
+++ b/app/components/formElements/schemaToForm/renderZodEnum.tsx
@@ -1,9 +1,5 @@
 import get from "lodash/get";
 import type { z } from "zod";
-import Checkbox from "~/components/formElements/Checkbox";
-import RadioGroup from "~/components/formElements/RadioGroup";
-import Select from "~/components/formElements/Select";
-import TileGroup from "~/components/formElements/tile/TileGroup";
 import type { StrapiFormComponent } from "~/services/cms/models/formElements/StrapiFormComponent";
 import { sortSchemaOptionsByFormComponents } from "./sortSchemaOptionsByFormComponents";
 import KernRadioGroup from "~/components/kern/formElements/KernRadioGroup";
@@ -20,7 +16,6 @@ export function renderZodEnum(
   schema: ZodEnum,
   fieldName: string,
   matchingElement?: StrapiFormComponent,
-  showKernUX?: boolean,
 ) {
   const label = get(matchingElement, "label");
   const errorMessages = get(matchingElement, "errorMessages");
@@ -33,16 +28,8 @@ export function renderZodEnum(
   let options = sortedOptions.map((value) => ({ value, text: value }));
   switch (matchingElement?.__component) {
     case "form-elements.checkbox":
-      return showKernUX ? (
+      return (
         <KernCheckbox
-          key={fieldName}
-          name={fieldName}
-          label={label}
-          required={matchingElement.required}
-          errorMessage={matchingElement.errorMessage}
-        />
-      ) : (
-        <Checkbox
           key={fieldName}
           name={fieldName}
           label={label}
@@ -55,22 +42,8 @@ export function renderZodEnum(
       const cmsObject = Object.fromEntries(
         cmsOptions?.map(({ value, ...rest }) => [value, rest]),
       );
-      return showKernUX ? (
+      return (
         <KernTile
-          key={fieldName}
-          name={fieldName}
-          useTwoColumns={matchingElement.useTwoColumns}
-          label={label}
-          errorMessages={errorMessages}
-          options={options.map(({ value }) => ({
-            value,
-            description: cmsObject[value]?.description,
-            image: cmsObject[value]?.image,
-            title: cmsObject[value]?.title ?? value,
-          }))}
-        />
-      ) : (
-        <TileGroup
           key={fieldName}
           name={fieldName}
           useTwoColumns={matchingElement.useTwoColumns}
@@ -94,7 +67,7 @@ export function renderZodEnum(
         value,
         text: cmsObject[value]?.text ?? text,
       }));
-      return showKernUX ? (
+      return (
         <KernSelect
           name={fieldName}
           key={fieldName}
@@ -103,17 +76,6 @@ export function renderZodEnum(
           errorMessages={errorMessages}
           width={get(matchingElement, "width")}
           placeholder={get(matchingElement, "placeholder")}
-        />
-      ) : (
-        <Select
-          name={fieldName}
-          key={fieldName}
-          label={label}
-          options={options}
-          placeholder={get(matchingElement, "placeholder")}
-          altLabel={get(matchingElement, "altLabel")}
-          errorMessages={errorMessages}
-          width={get(matchingElement, "width")}
         />
       );
     }
@@ -128,17 +90,8 @@ export function renderZodEnum(
           text: cmsObject[value]?.text ?? text,
         }));
       }
-      return showKernUX ? (
+      return (
         <KernRadioGroup
-          key={fieldName}
-          name={fieldName}
-          label={label}
-          altLabel={get(matchingElement, "altLabel")}
-          errorMessages={errorMessages}
-          options={options}
-        />
-      ) : (
-        <RadioGroup
           key={fieldName}
           name={fieldName}
           label={label}
@@ -148,17 +101,8 @@ export function renderZodEnum(
         />
       );
     default:
-      return showKernUX ? (
+      return (
         <KernRadioGroup
-          key={fieldName}
-          name={fieldName}
-          label={label}
-          altLabel={get(matchingElement, "altLabel")}
-          errorMessages={errorMessages}
-          options={options}
-        />
-      ) : (
-        <RadioGroup
           key={fieldName}
           name={fieldName}
           label={label}

--- a/app/components/formElements/schemaToForm/renderZodObject.tsx
+++ b/app/components/formElements/schemaToForm/renderZodObject.tsx
@@ -1,8 +1,5 @@
 import type { z, ZodObject } from "zod";
 import { type StrapiFormComponent } from "~/services/cms/models/formElements/StrapiFormComponent";
-import { ExclusiveCheckboxes } from "../exclusiveCheckboxes/ExclusiveCheckboxes";
-import SplitDateInput from "../SplitDateInput";
-import { SchemaComponents } from "../SchemaComponents";
 import mapKeys from "lodash/mapKeys";
 import { KernSchemaComponents } from "~/components/kernFormElements/KernSchemaComponents";
 import { KernExclusiveCheckboxes } from "~/components/kern/formElements/exclusiveCheckboxes/KernExclusiveCheckboxes";
@@ -13,7 +10,6 @@ export const renderZodObject = (
   fieldName: string,
   readOnlyFieldNames: string[],
   formComponents?: StrapiFormComponent[],
-  showKernUX?: boolean,
 ) => {
   if (nestedSchema.meta()?.description === "exclusive_checkbox") {
     const labels = Object.fromEntries(
@@ -23,15 +19,8 @@ export const renderZodObject = (
         .map((el) => [el.name.split(".").at(-1)!, el.label]),
     );
 
-    return showKernUX ? (
+    return (
       <KernExclusiveCheckboxes
-        key={fieldName}
-        name={fieldName}
-        options={Object.keys(nestedSchema.shape)}
-        labels={labels}
-      />
-    ) : (
-      <ExclusiveCheckboxes
         key={fieldName}
         name={fieldName}
         options={Object.keys(nestedSchema.shape)}
@@ -40,27 +29,15 @@ export const renderZodObject = (
     );
   }
   if (nestedSchema.meta()?.description === "split_date") {
-    return showKernUX ? (
-      <KernSplitDateInput key={fieldName} name={fieldName} />
-    ) : (
-      <SplitDateInput key={fieldName} name={fieldName} />
-    );
+    return <KernSplitDateInput key={fieldName} name={fieldName} />;
   }
   // ZodObjects are multiple nested schemas, whos keys need to be prepended with the fieldname (e.g. "name.firstName")
   const innerSchema = mapKeys(
     nestedSchema.shape,
     (_, key) => `${fieldName}.${key}`,
   );
-  return showKernUX ? (
+  return (
     <KernSchemaComponents
-      key={fieldName}
-      pageSchema={innerSchema}
-      formComponents={formComponents}
-      showKernUX={showKernUX}
-      readOnlyFieldNames={readOnlyFieldNames}
-    />
-  ) : (
-    <SchemaComponents
       key={fieldName}
       pageSchema={innerSchema}
       formComponents={formComponents}

--- a/app/components/formElements/schemaToForm/renderZodString.tsx
+++ b/app/components/formElements/schemaToForm/renderZodString.tsx
@@ -1,16 +1,13 @@
 import pick from "lodash/pick";
 import type { z } from "zod";
-import DateInput from "~/components/formElements/DateInput";
-import Input, { type InputProps } from "~/components/formElements/Input";
-import Textarea from "~/components/formElements/Textarea";
-import TimeInput from "~/components/formElements/TimeInput";
 import type { StrapiFormComponent } from "~/services/cms/models/formElements/StrapiFormComponent";
 import KernTextarea from "~/components/kern/formElements/Textarea";
-import TextInput from "~/components/kern/formElements/input/TextInput";
+import TextInput, {
+  type InputProps,
+} from "~/components/kern/formElements/input/TextInput";
 import NumberInput from "~/components/kern/formElements/input/NumberInput";
 import TelephoneInput from "~/components/kern/formElements/input/TelephoneInput";
 import KernTimeInput from "~/components/kern/formElements/input/KernTimeInput";
-import AutoSuggestInput from "../AutoSuggestInput";
 import KernAutoSuggestInput from "~/components/kern/formElements/autoSuggest/KernAutoSuggestInput";
 import KernDateInput from "~/components/kern/formElements/input/KernDateInput";
 
@@ -22,7 +19,6 @@ export const renderZodString = (
   fieldName: string,
   isFieldReadOnly: boolean,
   matchingElement?: StrapiFormComponent,
-  showKernUX?: boolean,
 ) => {
   const sharedProps = {
     name: fieldName,
@@ -36,40 +32,24 @@ export const renderZodString = (
   } satisfies InputProps;
 
   if (matchingElement?.__component === "form-elements.textarea")
-    return showKernUX ? (
+    return (
       <KernTextarea
-        key={fieldName}
-        {...sharedProps}
-        {...pick(matchingElement, ["details", "description", "maxLength"])}
-      />
-    ) : (
-      <Textarea
         key={fieldName}
         {...sharedProps}
         {...pick(matchingElement, ["details", "description", "maxLength"])}
       />
     );
   if (matchingElement?.__component === "form-elements.date-input")
-    return showKernUX ? (
-      <KernDateInput key={fieldName} {...inputProps} />
-    ) : (
-      <DateInput key={fieldName} {...inputProps} />
-    );
+    return <KernDateInput key={fieldName} {...inputProps} />;
   if (matchingElement?.__component === "form-elements.time-input")
-    return showKernUX ? (
-      <KernTimeInput key={fieldName} {...inputProps} />
-    ) : (
-      <TimeInput key={fieldName} {...inputProps} />
-    );
+    return <KernTimeInput key={fieldName} {...inputProps} />;
   if (matchingElement?.__component === "form-elements.auto-suggest-input")
-    return showKernUX ? (
+    return (
       <KernAutoSuggestInput
         key={fieldName}
         {...matchingElement}
         {...inputProps}
       />
-    ) : (
-      <AutoSuggestInput key={fieldName} {...matchingElement} {...inputProps} />
     );
 
   const inputType =
@@ -79,17 +59,14 @@ export const renderZodString = (
       | "telephone"
       | undefined) ?? "text";
 
-  if (showKernUX) {
-    switch (inputType) {
-      case "text":
-        return <TextInput key={fieldName} {...inputProps} />;
-      case "number":
-        return <NumberInput key={fieldName} {...inputProps} />;
-      case "telephone":
-        return <TelephoneInput key={fieldName} {...inputProps} />;
-      default:
-        return <TextInput key={fieldName} {...inputProps} />;
-    }
+  switch (inputType) {
+    case "text":
+      return <TextInput key={fieldName} {...inputProps} />;
+    case "number":
+      return <NumberInput key={fieldName} {...inputProps} />;
+    case "telephone":
+      return <TelephoneInput key={fieldName} {...inputProps} />;
+    default:
+      return <TextInput key={fieldName} {...inputProps} />;
   }
-  return <Input key={fieldName} {...inputProps} />;
 };

--- a/app/components/kern/common/KernIcon.tsx
+++ b/app/components/kern/common/KernIcon.tsx
@@ -20,6 +20,7 @@ export function KernIcon({
       fill="currentColor"
       aria-hidden="true"
       viewBox="0 -960 960 960"
+      data-testid={`icon-${name}`}
     >
       {title && <title>{title}</title>}
       <path d={IconPaths[name]} />

--- a/app/components/kern/formElements/InputError.tsx
+++ b/app/components/kern/formElements/InputError.tsx
@@ -8,7 +8,7 @@ type InputErrorProps = PropsWithChildren<{
 const InputError = ({ id, children }: InputErrorProps) => {
   if (!children) return null;
   return (
-    <p className="kern-error" id={id} role="alert">
+    <p className="kern-error" data-testid="inputError" id={id} role="alert">
       <KernIcon
         name="emergency-home"
         className="fill-kern-feedback-danger! forced-color-adjust-auto"

--- a/app/components/kern/formElements/KernSelect.tsx
+++ b/app/components/kern/formElements/KernSelect.tsx
@@ -33,6 +33,7 @@ const KernSelect = ({
         </label>
       )}
       <div
+        data-testid="select-wrapper"
         className={classNames(
           "kern-form-input__select-wrapper",
           {
@@ -50,6 +51,7 @@ const KernSelect = ({
           aria-required={
             !!errorMessages?.find((err) => err.code === "required")
           }
+          data-testid="select"
         >
           {placeholder && (
             <option disabled value="">

--- a/app/components/kern/formElements/tile/KernTile.tsx
+++ b/app/components/kern/formElements/tile/KernTile.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, useState } from "react";
 import { useJsAvailable } from "~/components/hooks/useJsAvailable";
 import { type ErrorMessageProps } from "~/components/common/types";
 import KernTileRadio, { type KernTileOptions } from "./KernTileRadio";
-import { KernIcon } from "~/components/kern/common/KernIcon";
+import InputError from "../InputError";
 
 type KernTileProps = Readonly<{
   name: string;
@@ -72,13 +72,7 @@ const KernTile = ({
       </div>
       <div className="pt-16 pb-16">
         {errorToDisplay && (
-          <p className="kern-error" id={errorId} role="alert">
-            <KernIcon
-              name="emergency-home"
-              className="fill-kern-feedback-danger!"
-            />
-            <span className="text-kern-feedback-danger">{errorToDisplay}</span>
-          </p>
+          <InputError id={errorId}>{errorToDisplay}</InputError>
         )}
       </div>
     </fieldset>

--- a/app/components/kernFormElements/KernSchemaComponents.tsx
+++ b/app/components/kernFormElements/KernSchemaComponents.tsx
@@ -38,7 +38,6 @@ type Props = {
   pageSchema: SchemaObject;
   formComponents?: StrapiFormComponent[];
   className?: string;
-  showKernUX?: boolean;
   readOnlyFieldNames: string[];
 };
 
@@ -83,7 +82,6 @@ export const KernSchemaComponents = ({
   pageSchema,
   formComponents,
   className,
-  showKernUX = true,
   readOnlyFieldNames,
 }: Props) => {
   const sortedFieldsSchema = sortSchemaByFormComponents(
@@ -102,12 +100,7 @@ export const KernSchemaComponents = ({
         );
 
         if (fieldSetGroup !== undefined) {
-          return renderFieldSet(
-            fieldName,
-            fieldSetGroup,
-            readOnlyFieldNames,
-            showKernUX,
-          );
+          return renderFieldSet(fieldName, fieldSetGroup, readOnlyFieldNames);
         }
 
         const matchingElement = formComponents
@@ -135,25 +128,14 @@ export const KernSchemaComponents = ({
             fieldName,
             readOnlyFieldNames,
             formComponents,
-            showKernUX,
           );
         }
 
         if (isZodEnum(nestedSchema))
-          return renderZodEnum(
-            nestedSchema,
-            fieldName,
-            matchingElement,
-            showKernUX,
-          );
+          return renderZodEnum(nestedSchema, fieldName, matchingElement);
 
         if (isZodString(nestedSchema))
-          return renderZodString(
-            fieldName,
-            isFieldReadOnly,
-            matchingElement,
-            showKernUX,
-          );
+          return renderZodString(fieldName, isFieldReadOnly, matchingElement);
       })}
     </div>
   );

--- a/tests/factories/cmsModels/strapiCheckboxComponent.ts
+++ b/tests/factories/cmsModels/strapiCheckboxComponent.ts
@@ -32,7 +32,7 @@ export function getStrapiCheckboxComponent(
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };

--- a/tests/factories/cmsModels/strapiDropdownComponent.ts
+++ b/tests/factories/cmsModels/strapiDropdownComponent.ts
@@ -33,8 +33,11 @@ export function getStrapiDropdownComponent(
     expectDropdownErrorToExist: async function () {
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
+        expect(screen.getByTestId("select-wrapper")).toHaveClass(
+          "kern-form-input__select-wrapper--error",
+        );
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };

--- a/tests/factories/cmsModels/strapiInputComponent.ts
+++ b/tests/factories/cmsModels/strapiInputComponent.ts
@@ -26,9 +26,11 @@ export function getStrapiInputComponent<T extends InputType = "input">(
     expectInputErrorToExist: async function () {
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
-        expect(screen.getByRole("textbox")).toHaveClass("has-error");
+        expect(screen.getByRole("textbox")).toHaveClass(
+          "kern-form-input__input--error",
+        );
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };

--- a/tests/factories/cmsModels/strapiSelectComponent.ts
+++ b/tests/factories/cmsModels/strapiSelectComponent.ts
@@ -29,7 +29,7 @@ export function getStrapiSelectComponent(
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };

--- a/tests/factories/cmsModels/strapiTextareaComponent.ts
+++ b/tests/factories/cmsModels/strapiTextareaComponent.ts
@@ -20,10 +20,10 @@ export function getStrapiTextareaComponent(
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
         expect(screen.getByPlaceholderText(`textarea`)).toHaveClass(
-          "has-error",
+          "kern-form-input__input--error",
         );
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };

--- a/tests/factories/cmsModels/strapiTileGroupComponent.ts
+++ b/tests/factories/cmsModels/strapiTileGroupComponent.ts
@@ -25,7 +25,7 @@ export function getStrapiTileGroupComponent(
       await waitFor(() => {
         expect(screen.getByText(errorCode.text)).toBeInTheDocument();
         expect(screen.getByTestId("inputError")).toBeInTheDocument();
-        expect(screen.getByTestId("ErrorOutlineIcon")).toBeInTheDocument();
+        expect(screen.getByTestId("icon-emergency-home")).toBeInTheDocument();
       });
     },
   };


### PR DESCRIPTION
This PR:

- remove showKernUX from render
- update tests
- add data-testId to InputError
- fix tests according to new component structure
- remove old icons from test assertions
- add data-testId to icons to assert error messages
- use InputError instead of hardcoded error messages 