### PR TITLE
fix(csrf): handle old and new API

### DIFF
--- a/app/services/security/csrf/__test__/validatedSession.test.ts
+++ b/app/services/security/csrf/__test__/validatedSession.test.ts
@@ -78,6 +78,33 @@ describe("validatedSession", () => {
     );
   });
 
+  it("should handle both an array of CSRF tokens, as well as a single token", async () => {
+    const mockSession: Session = createSession();
+    mockSession.set(CSRFKey, ["csrf1", "csrf2"]);
+    mockMainSessionFromCookieHeader(mockSession);
+    const formData = new FormData();
+    formData.append(CSRFKey, "csrf2");
+
+    const request = new Request("http://localhost:3000", {
+      method: "POST",
+      body: formData,
+    });
+
+    const actual = await validatedSession(request);
+    expect(actual.isOk).toBe(true);
+
+    mockSession.set(CSRFKey, "singleCsrf");
+    formData.set(CSRFKey, "singleCsrf");
+
+    const requestSingle = new Request("http://localhost:3000", {
+      method: "POST",
+      body: formData,
+    });
+
+    const actualSingle = await validatedSession(requestSingle);
+    expect(actualSingle.isOk).toBe(true);
+  });
+
   it("should return a result ok in case everything is ok", async () => {
     const mockSession: Session = createSession();
     mockMainSessionFromCookieHeader(mockSession);

--- a/app/services/security/csrf/getCSRFFromSession.server.ts
+++ b/app/services/security/csrf/getCSRFFromSession.server.ts
@@ -2,4 +2,4 @@ import type { Session } from "react-router";
 import { CSRFKey } from "./csrfKey";
 
 export const getCSRFFromSession = (session: Session) =>
-  session.get(CSRFKey) as string | null;
+  session.get(CSRFKey) as string | null | string[];

--- a/app/services/security/csrf/validatedSession.server.ts
+++ b/app/services/security/csrf/validatedSession.server.ts
@@ -22,8 +22,15 @@ async function validateCSRFToken(
   const csrfTokensSession = getCSRFFromSession(session);
   if (!csrfTokensSession) return Result.err(ERROR_MESSAGE_TOKEN_SESSION);
 
-  if (csrfTokensSession !== csrfTokenForm)
-    return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
+  if (Array.isArray(csrfTokensSession)) {
+    if (!csrfTokensSession.includes(csrfTokenForm)) {
+      return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
+    }
+  } else {
+    if (csrfTokensSession !== csrfTokenForm) {
+      return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
+    }
+  }
 
   return Result.ok();
 }

--- a/app/services/security/csrf/validatedSession.server.ts
+++ b/app/services/security/csrf/validatedSession.server.ts
@@ -22,14 +22,12 @@ async function validateCSRFToken(
   const csrfTokensSession = getCSRFFromSession(session);
   if (!csrfTokensSession) return Result.err(ERROR_MESSAGE_TOKEN_SESSION);
 
-  if (Array.isArray(csrfTokensSession)) {
-    if (!csrfTokensSession.includes(csrfTokenForm)) {
-      return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
-    }
-  } else {
-    if (csrfTokensSession !== csrfTokenForm) {
-      return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
-    }
+  const isTokenMatch = Array.isArray(csrfTokensSession)
+    ? csrfTokensSession.includes(csrfTokenForm)
+    : csrfTokensSession === csrfTokenForm;
+
+  if (!isTokenMatch) {
+    return Result.err(ERROR_MESSAGE_TOKEN_SESSION_NOT_MATCH);
   }
 
   return Result.ok();

--- a/app/services/session.server/__test__/anyUserData.test.ts
+++ b/app/services/session.server/__test__/anyUserData.test.ts
@@ -1,0 +1,55 @@
+import { createSession } from "react-router";
+import { CSRFKey } from "~/services/security/csrf/csrfKey";
+import { getSessionManager } from "~/services/session.server";
+import { anyUserData } from "~/services/session.server/anyUserData.server";
+
+const mockSession = createSession({
+  data: {
+    userId: "123",
+    __vaultKey: "vault",
+    [CSRFKey]: "csrfToken",
+  },
+});
+
+vi.mock("~/services/session.server", async () => ({
+  ...(await vi.importActual("~/services/session.server")),
+  getSessionManager: vi.fn(() => ({
+    getSession: vi.fn().mockResolvedValue(mockSession),
+  })),
+}));
+
+describe("anyUserData", () => {
+  it("should return true if any session contains user data", async () => {
+    const mockRequest = new Request("http://localhost", {
+      headers: {
+        Cookie: "",
+      },
+    });
+
+    // Call the function and assert the result
+    const result = await anyUserData(mockRequest);
+    expect(result).toBe(true);
+  });
+
+  it("should return false if no session contains user data", async () => {
+    vi.mocked(getSessionManager).mockReturnValue({
+      getSession: vi.fn().mockResolvedValue({
+        data: {
+          __vaultKey: "vault",
+          [CSRFKey]: "csrfToken",
+        },
+      }),
+      commitSession: vi.fn(),
+      destroySession: vi.fn(),
+    });
+    const mockRequest = new Request("http://localhost", {
+      headers: {
+        Cookie: "",
+      },
+    });
+
+    // Call the function and assert the result
+    const result = await anyUserData(mockRequest);
+    expect(result).toBe(false);
+  });
+});

--- a/app/services/session.server/__test__/index.test.ts
+++ b/app/services/session.server/__test__/index.test.ts
@@ -60,6 +60,14 @@ describe("index", () => {
       expect(csrf).toBe("existing-token");
     });
 
+    it("should return the first CSRF token if the session contains an array of CSRF tokens", async () => {
+      session = reactRouter.createSession({ [CSRFKey]: ["token1", "token2"] });
+      const { csrf } = await sessionServices.initializeMainSession(
+        new Request(baseUrl),
+      );
+      expect(csrf).toBe("token1");
+    });
+
     it("should set the last visited step if inside of a flow", async () => {
       session = reactRouter.createSession({});
       const flowId: FlowId = "/beratungshilfe/antrag";

--- a/app/services/session.server/anyUserData.server.ts
+++ b/app/services/session.server/anyUserData.server.ts
@@ -1,14 +1,17 @@
+import { CSRFKey } from "~/services/security/csrf/csrfKey";
 import { allSessionUserData, getSessionManager } from ".";
 
 export async function anyUserData(request: Request) {
   const cookieHeader = request.headers.get("Cookie");
   const sessionDataSizesPromises = allSessionUserData.map((context) =>
-    getSessionManager(context)
-      .getSession(cookieHeader)
-      .then((session) => Object.keys(session.data).length),
+    getSessionManager(context).getSession(cookieHeader),
   );
 
-  return Promise.all(sessionDataSizesPromises).then((sessionDataSizes) => {
-    return sessionDataSizes.some((sessionDataSize) => sessionDataSize > 0);
+  return Promise.all(sessionDataSizesPromises).then((sessions) => {
+    return sessions.some((sessionData) =>
+      Object.keys(sessionData.data).some(
+        (key) => key !== "__vaultKey" && key !== CSRFKey,
+      ),
+    );
   });
 }

--- a/app/services/session.server/index.ts
+++ b/app/services/session.server/index.ts
@@ -152,7 +152,7 @@ export const initializeMainSession = async (request: Request) => {
   return {
     headers,
     feedback,
-    csrf,
+    csrf: Array.isArray(csrf) ? csrf[0] : csrf,
     trackingConsent,
   };
 };


### PR DESCRIPTION
This PR adds backwards compatibility with the old CSRF token saving mechanism (as an array), and also ensures that the Personal Data Deletion banner is only shown in the event that the user _has_ any data, i.e. not just a csrf/vaultKey stored in the session

- [x] Add test
- [x] Any user data should only check user data exclude user metadata such as `_csrf`