### PR TITLE
RAST-839 fix tile border flash in HCM mode

### DIFF
--- a/app/styles.kern.css
+++ b/app/styles.kern.css
@@ -50,7 +50,7 @@
 
   .detail-summary:focus-within,
   .kern-tile:focus-within {
-    border-radius: var(--kern-metric-border-radius-default, 0.25rem);
+    border-radius: var(--kern-metric-border-radius-large, 0.25rem);
     box-shadow:
       0 0 0 2px var(--kern-color-action-on-default),
       0 0 0 4px var(--kern-color-action-focus-border-inside),


### PR DESCRIPTION
border size difference causes a flash when selecting a tile in HCM mode