### PR TITLE
accessibility(KERN): fix icon on details component

### DIFF
--- a/app/components/content/Details.tsx
+++ b/app/components/content/Details.tsx
@@ -26,12 +26,11 @@ export const Details = ({ title, content }: DetailsProps) => {
           aria-expanded={isOpen}
           className="text-kern-action-default! kern-body kern-body--bold flex items-center focus:outline-hidden cursor-pointer list-none hover:underline"
         >
-          <span className="mr-kern-space-small">
-            {isOpen ? (
-              <Icon name="keyboard-arrow-up" />
-            ) : (
-              <Icon name="keyboard-arrow-down" />
-            )}
+          <span className="mr-kern-space-small flex items-center flex-none">
+            <Icon
+              name={isOpen ? "keyboard-arrow-up" : "keyboard-arrow-down"}
+              className="shrink-0 min-w-[1em] min-h-[1em]"
+            />
           </span>
           {title}
         </summary>


### PR DESCRIPTION
This PR fix the arrow icon scalability on the details component in mobile with zoom 200%

**Before**


<img width="415" height="705" alt="Screenshot 2026-05-07 at 11 35 41" src="https://github.com/user-attachments/assets/93e082ab-e066-46ad-ac64-5430004b99aa" />

**After**


<img width="450" height="712" alt="Screenshot 2026-05-07 at 11 25 39" src="https://github.com/user-attachments/assets/8e60a08a-bd9d-4898-ad58-9724585dbcf3" />


**Desktop 200%**


<img width="1481" height="1000" alt="Screenshot 2026-05-07 at 11 38 12" src="https://github.com/user-attachments/assets/31871aa4-e767-4f8d-8714-06bc99f91ab7" />


**Mobile Landscape 200%**


<img width="976" height="455" alt="Screenshot 2026-05-07 at 11 37 38" src="https://github.com/user-attachments/assets/992cb0eb-620a-4e24-8ea6-ded8bcb34fad" />
