### PR TITLE
Remove react-router-dom

### DIFF
--- a/app/components/content/userFeedback/__test__/FeedbackFormBox.test.tsx
+++ b/app/components/content/userFeedback/__test__/FeedbackFormBox.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { createMemoryRouter, RouterProvider } from "react-router-dom"; // use react-router-dom only for test, the react-router does not work
+import { createMemoryRouter, RouterProvider } from "react-router";
 import { FeedbackFormBox, FEEDBACK_FIELD_NAME } from "../FeedbackFormBox";
 
 const SUBMIT_BUTTON_FEEDBACK = "Submit button";

--- a/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
+++ b/app/components/formElements/__test__/ValidatedFlowForm.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
-import { createMemoryRouter, RouterProvider } from "react-router-dom"; // use react-router-dom only for test, the react-router does not work
+import { createMemoryRouter, RouterProvider } from "react-router";
 import { z } from "zod";
 import { getStrapiCheckboxComponent } from "tests/factories/cmsModels/strapiCheckboxComponent";
 import { getStrapiDropdownComponent } from "tests/factories/cmsModels/strapiDropdownComponent";

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "oxlint": "^1.67.0",
     "p-map": "^7.0.4",
     "prettier": "^3.8.3",
-    "react-router-dom": "^7.16.0",
     "size-limit": "^12.1.0",
     "storybook": "^10.4.1",
     "tailwindcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,9 +268,6 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
-      react-router-dom:
-        specifier: ^7.16.0
-        version: 7.16.0(react-dom@19.2.6)(react@19.2.6)
       size-limit:
         specifier: ^12.1.0
         version: 12.1.0(jiti@2.7.0)
@@ -4360,13 +4357,6 @@ packages:
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
-
-  react-router-dom@7.16.0:
-    resolution: {integrity: sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
 
   react-router@7.16.0:
     resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
@@ -9301,12 +9291,6 @@ snapshots:
   react-property@2.0.2: {}
 
   react-refresh@0.14.2: {}
-
-  react-router-dom@7.16.0(react-dom@19.2.6)(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-router: 7.16.0(react-dom@19.2.6)(react@19.2.6)
 
   react-router@7.16.0(react-dom@19.2.6)(react@19.2.6):
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,10 @@ export default defineConfig((config) => ({
     sourcemap: useSentry,
     target: config.isSsrBuild ? "esnext" : undefined, // Allows top-level await in server-only files
   },
-  resolve: { tsconfigPaths: true },
+  resolve: {
+    tsconfigPaths: true,
+    ...(isVitest ? { conditions: ["module-sync"] } : {}),
+  },
   ssr: { noExternal: ["@digitalservicebund/icons"] },
   test: {
     globals: true,


### PR DESCRIPTION
### Background
We have been using the dependency `react-router-dom` due issues during tests that requires action data. However, we can use this [workaround](https://github.com/remix-run/react-router/issues/12785#issuecomment-2844943803) to solve this issue. Also `react-router-dom` will be removed in the next major version (check it out [here](https://github.com/remix-run/react-router/discussions/14468))

### Changes

- Add conditions: ["module-sync"] in vite.config.ts when running vitest
- Remove `react-router-dom` from tests and package.json