### PR TITLE
fix(KERN): add hyphens to exclusive checkboxes

### DIFF
--- a/app/components/formElements/inputs/exclusiveCheckboxes/ExclusiveCheckboxInput.tsx
+++ b/app/components/formElements/inputs/exclusiveCheckboxes/ExclusiveCheckboxInput.tsx
@@ -55,7 +55,14 @@ export const ExclusiveCheckboxInput = ({
             )
           }
         />
-        {label && <InputLabel name={name} label={label} suffix={suffix} />}
+        {label && (
+          <InputLabel
+            name={name}
+            label={label}
+            suffix={suffix}
+            className="hyphens-auto!"
+          />
+        )}
       </div>
     </div>
   );

--- a/app/components/formElements/inputs/label/InputLabel.tsx
+++ b/app/components/formElements/inputs/label/InputLabel.tsx
@@ -1,14 +1,18 @@
+import classNames from "classnames";
+
 export const InputLabel = ({
   name,
   label,
   suffix,
+  className,
 }: {
   label: string | React.ReactNode;
   suffix?: string;
   name: string;
+  className?: string;
 }) => {
   return (
-    <label className="kern-label" htmlFor={name}>
+    <label className={classNames("kern-label", className)} htmlFor={name}>
       {label}
       {suffix && <span className="kern-label__optional">{suffix}</span>}
     </label>


### PR DESCRIPTION
This PR fix the exclusive checkboxes labels hyphens on mobile in 200% 

**Before**

<img width="402" height="689" alt="Screenshot 2026-06-17 at 11 05 33" src="https://github.com/user-attachments/assets/c918de04-9d91-40e5-baaa-2b640a647bf0" />

**After**

<img width="400" height="698" alt="Screenshot 2026-06-17 at 11 05 10" src="https://github.com/user-attachments/assets/e3af9604-a8db-400f-875a-cbfffba8b33d" />
