### PR TITLE
refactor(Overflow): Add global overflow/word-break instead of in specific places in the codebase

### DIFF
--- a/app/components/common/Heading.tsx
+++ b/app/components/common/Heading.tsx
@@ -59,7 +59,7 @@ const Heading = ({
         className="px-kern-space-large lg:px-0 xl:px-0"
       >
         <Tag
-          className={`${sizeClass} p-0! ${className ?? ""} outline-none break-words`}
+          className={`${sizeClass} p-0! ${className ?? ""} outline-none`}
           tabIndex={tabIndex}
           id={elementId}
           aria-describedby={ariaDescribedby}
@@ -71,7 +71,7 @@ const Heading = ({
   }
   return (
     <Tag
-      className={`${sizeClass} p-0! ${className ?? ""} hyphens-auto outline-none break-words`}
+      className={`${sizeClass} p-0! ${className ?? ""} outline-none`}
       tabIndex={tabIndex}
       id={elementId}
       aria-describedby={ariaDescribedby}

--- a/app/components/content/Box.tsx
+++ b/app/components/content/Box.tsx
@@ -33,7 +33,7 @@ const Box = ({
 
   const contentBlock = (
     <div className="flex flex-col">
-      <div className="flex flex-col wrap-break-word gap-kern-space-default">
+      <div className="flex flex-col gap-kern-space-default">
         {label && (
           <Label
             {...label}

--- a/app/components/formElements/inputs/exclusiveCheckboxes/ExclusiveCheckboxInput.tsx
+++ b/app/components/formElements/inputs/exclusiveCheckboxes/ExclusiveCheckboxInput.tsx
@@ -55,14 +55,7 @@ export const ExclusiveCheckboxInput = ({
             )
           }
         />
-        {label && (
-          <InputLabel
-            name={name}
-            label={label}
-            suffix={suffix}
-            className="hyphens-auto!"
-          />
-        )}
+        {label && <InputLabel name={name} label={label} suffix={suffix} />}
       </div>
     </div>
   );

--- a/app/components/formElements/inputs/tile/TileContent.tsx
+++ b/app/components/formElements/inputs/tile/TileContent.tsx
@@ -37,10 +37,7 @@ const TileContent = ({
       <div>
         {title && <h3 className="kern-body kern-body--bold">{title}</h3>}
         {description && (
-          <p
-            id={descriptionId}
-            className="kern-body kern-body--muted break-words"
-          >
+          <p id={descriptionId} className="kern-body kern-body--muted">
             {description}
           </p>
         )}

--- a/app/components/layout/PageHeader.tsx
+++ b/app/components/layout/PageHeader.tsx
@@ -71,7 +71,7 @@ export default function PageHeader({
 
                 <a
                   href={"/gebaerdensprache"}
-                  className="flex items-center! kern-link text-kern-static-small! no-underline! hover:underline! hyphens-auto"
+                  className="flex items-center! kern-link text-kern-static-small! no-underline! hover:underline!"
                 >
                   <Icon name="sign-language" />
                   {translations.pageHeader.gebaerdensprache.de}

--- a/app/styles.kern.css
+++ b/app/styles.kern.css
@@ -48,6 +48,11 @@
 
   /* ------------------------------- */
 
+  body {
+    hyphens: auto;
+    overflow-wrap: break-word;
+  }
+
   .detail-summary:focus-within,
   .kern-tile:focus-within {
     border-radius: var(--kern-metric-border-radius-large, 0.25rem);

--- a/app/styles.kern.css
+++ b/app/styles.kern.css
@@ -49,8 +49,8 @@
   /* ------------------------------- */
 
   body {
-    hyphens: auto;
-    overflow-wrap: break-word;
+    @apply hyphens-auto;
+    @apply wrap-break-word;
   }
 
   .detail-summary:focus-within,


### PR DESCRIPTION
Noticed that we're adding a lot of "hyphens-auto" or overflow-break-word in a lot of different places, when we could just add a global style override. I can't really think of a scenario in which we *don't* want the default to be to break words. And where we want it to not wrap, we're usually overriding it anyways.
