### PR TITLE
APL-92 engine array summary fixes

### DIFF
--- a/app/services/flow/newFlowEngine/__test__/compileFlow.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/compileFlow.test.ts
@@ -162,7 +162,9 @@ describe("compileFlow", () => {
       });
 
       it("has entryPoint undefined because the node is not a summary page", () => {
-        expect(nonSummaryFlow.getArrayInfo("/anzahl")?.entryPoint).toBeUndefined();
+        expect(
+          nonSummaryFlow.getArrayInfo("/anzahl")?.entryPoint,
+        ).toBeUndefined();
       });
 
       it("infers nested array name for a multi-level target stepId", () => {
@@ -187,9 +189,9 @@ describe("compileFlow", () => {
           transitions: nestedTransitions,
         });
 
-        expect(
-          nestedFlow.getArrayInfo("/parents/#/childrenAnzahl")?.name,
-        ).toBe("parents#children");
+        expect(nestedFlow.getArrayInfo("/parents/#/childrenAnzahl")?.name).toBe(
+          "parents#children",
+        );
         expect(
           nestedFlow.getArrayInfo("/parents/#/childrenAnzahl")?.entryPoint,
         ).toBeUndefined();

--- a/app/services/flow/newFlowEngine/__test__/compileFlow.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/compileFlow.test.ts
@@ -134,6 +134,67 @@ describe("compileFlow", () => {
     it("returns undefined for unknown path", () => {
       expect(arrayFlow.getArrayInfo("/unknown")).toBeUndefined();
     });
+
+    describe("non-summary node with addArrayItem", () => {
+      const nonSummaryPages = {
+        anzahl: { stepId: "/anzahl" },
+        item: { stepId: "/items/#/daten" },
+        done: { stepId: "/done" },
+      } as const;
+
+      const nonSummaryTransitions = {
+        anzahl: [
+          { target: "item" as const, type: "addArrayItem" as const },
+          { target: "done" as const },
+        ],
+        item: "done" as const,
+        done: null,
+      };
+
+      const nonSummaryFlow = compileFlow({
+        pages: nonSummaryPages,
+        initialStep: "anzahl",
+        transitions: nonSummaryTransitions,
+      });
+
+      it("infers the array name from the addArrayItem target stepId", () => {
+        expect(nonSummaryFlow.getArrayInfo("/anzahl")?.name).toBe("items");
+      });
+
+      it("has entryPoint undefined because the node is not a summary page", () => {
+        expect(nonSummaryFlow.getArrayInfo("/anzahl")?.entryPoint).toBeUndefined();
+      });
+
+      it("infers nested array name for a multi-level target stepId", () => {
+        const nestedPages = {
+          parentItem: { stepId: "/parents/#/childrenAnzahl" },
+          child: { stepId: "/parents/#/children/#/daten" },
+          done: { stepId: "/done" },
+        } as const;
+
+        const nestedTransitions = {
+          parentItem: [
+            { target: "child" as const, type: "addArrayItem" as const },
+            { target: "done" as const },
+          ],
+          child: "done" as const,
+          done: null,
+        };
+
+        const nestedFlow = compileFlow({
+          pages: nestedPages,
+          initialStep: "parentItem",
+          transitions: nestedTransitions,
+        });
+
+        expect(
+          nestedFlow.getArrayInfo("/parents/#/childrenAnzahl")?.name,
+        ).toBe("parents#children");
+        expect(
+          nestedFlow.getArrayInfo("/parents/#/childrenAnzahl")?.entryPoint,
+        ).toBeUndefined();
+      });
+    });
   });
 
   describe("isFinal", () => {

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -18,6 +18,9 @@ const transitions = {
 
 const flow = compileFlow({ pages, initialStep: "start", transitions });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const itemAt = (d: any, i: number) => d.items?.[i];
+
 describe("createFlowSession", () => {
   describe("invalid path", () => {
     it("throws an Error for an unknown path", () => {
@@ -230,8 +233,6 @@ describe("createFlowSession", () => {
       // "subCount" — a node that renders no summary and only exists to fan out. The
       // user reaches the nested daten page via the summary's add button, so Back
       // must return to the summary ("/list"), not the internal fan-out node.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const itemAt = (d: any, i: number) => d.items?.[i];
       const fanOutBackFlow = compileFlow({
         pages: {
           list: {
@@ -648,8 +649,6 @@ describe("createFlowSession", () => {
       // items share the "name" field with the top-level daten page, a scope leak
       // when exiting the sub-flow back to the summary would re-collect them under
       // the parent — this asserts that does not happen.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const itemAt = (d: any, i: number) => d.items?.[i];
       const nestedGuardedFlow = compileFlow({
         pages: {
           list: {

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -181,6 +181,113 @@ describe("createFlowSession", () => {
         "/gericht-pruefen/beklagte-person/kaufmann",
       );
     });
+
+    it("returns the summary as Back for a top-level array item page", () => {
+      // Regression guard: a top-level item's daten page is reached directly from
+      // its summary's add button, so Back must return to that summary — the fix for
+      // deeper fan-out nodes must not skip past a real summary.
+      const topLevelArrayFlow = compileFlow({
+        pages: {
+          list: {
+            stepId: "/list",
+            arraySummary: {
+              name: "items",
+              schema: z.array(z.object({ name: z.string() })),
+            },
+          },
+          itemDaten: {
+            stepId: "/items/#/daten",
+            pageSchema: { "items#name": z.string() },
+          },
+          done: { stepId: "/done" },
+        },
+        initialStep: "list",
+        transitions: {
+          list: [
+            { target: "itemDaten" as const, type: "addArrayItem" as const },
+            { target: "done" as const },
+          ],
+          itemDaten: "list" as const,
+          done: null,
+        },
+      });
+
+      const session = createFlowSession(
+        topLevelArrayFlow,
+        {
+          items: [{ name: "a" }],
+          pageData: { arrayIndexes: [0] },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        "/items/#/daten",
+      );
+
+      expect(session.prevPath).toBe("/list");
+    });
+
+    it("skips a bare fan-out node so Back returns to the summary it exits to", () => {
+      // A nested item's daten page is reached by an addArrayItem fan-out hosted on
+      // "subCount" — a node that renders no summary and only exists to fan out. The
+      // user reaches the nested daten page via the summary's add button, so Back
+      // must return to the summary ("/list"), not the internal fan-out node.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const itemAt = (d: any, i: number) => d.items?.[i];
+      const fanOutBackFlow = compileFlow({
+        pages: {
+          list: {
+            stepId: "/list",
+            arraySummary: {
+              name: "items",
+              schema: z.array(z.object({ gate: z.string() })),
+            },
+          },
+          itemDaten: {
+            stepId: "/items/#/daten",
+            pageSchema: { "items#gate": z.string() },
+          },
+          subCount: { stepId: "/items/#/count" },
+          subDaten: {
+            stepId: "/items/#/items/#/daten",
+            pageSchema: { "items#items#name": z.string() },
+          },
+          done: { stepId: "/done" },
+        },
+        initialStep: "list",
+        transitions: {
+          list: [
+            { target: "itemDaten" as const, type: "addArrayItem" as const },
+            { target: "done" as const },
+          ],
+          itemDaten: [
+            {
+              target: "subCount" as const,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              guard: (d: any) =>
+                itemAt(d, d.pageData?.arrayIndexes?.[0])?.gate === "yes",
+            },
+            { target: "list" as const },
+          ],
+          subCount: [
+            { target: "subDaten" as const, type: "addArrayItem" as const },
+            { target: "list" as const },
+          ],
+          subDaten: "subCount" as const,
+          done: null,
+        },
+      });
+
+      const session = createFlowSession(
+        fanOutBackFlow,
+        {
+          items: [{ gate: "yes", items: [{ name: "x" }] }],
+          pageData: { arrayIndexes: [0, 0] },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        "/items/#/items/#/daten",
+      );
+
+      expect(session.prevPath).toBe("/list");
+    });
   });
 
   describe("isReachable", () => {
@@ -532,6 +639,86 @@ describe("createFlowSession", () => {
     it("does not include pageData in prunedUserData", () => {
       const session = createFlowSession(flow, noData, "/start");
       expect(session.prunedUserData).not.toHaveProperty("pageData");
+    });
+
+    it("prunes a nested array under a parent whose guard no longer reaches it", () => {
+      // An item's nested array (same "items" shape, one level down) is only
+      // reachable when the item's gate passes (gate="yes"). When the gate fails,
+      // the nested items are unreachable and must be pruned. Because the nested
+      // items share the "name" field with the top-level daten page, a scope leak
+      // when exiting the sub-flow back to the summary would re-collect them under
+      // the parent — this asserts that does not happen.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const itemAt = (d: any, i: number) => d.items?.[i];
+      const nestedGuardedFlow = compileFlow({
+        pages: {
+          list: {
+            stepId: "/list",
+            arraySummary: {
+              name: "items",
+              schema: z.array(
+                z.object({ name: z.string(), gate: z.string().optional() }),
+              ),
+            },
+          },
+          itemDaten: {
+            stepId: "/items/#/daten",
+            pageSchema: { "items#name": z.string(), "items#gate": z.string() },
+          },
+          subList: {
+            stepId: "/items/#/items",
+            arraySummary: {
+              name: "items#items",
+              schema: z.array(z.object({ name: z.string() })),
+            },
+          },
+          subDaten: {
+            stepId: "/items/#/items/#/daten",
+            pageSchema: { "items#items#name": z.string() },
+          },
+          done: { stepId: "/done" },
+        },
+        initialStep: "list",
+        transitions: {
+          list: [
+            { target: "itemDaten" as const, type: "addArrayItem" as const },
+            { target: "done" as const },
+          ],
+          itemDaten: [
+            {
+              target: "subList" as const,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              guard: (d: any) =>
+                itemAt(d, d.pageData?.arrayIndexes?.[0])?.gate === "yes",
+            },
+            { target: "list" as const },
+          ],
+          subList: [
+            { target: "subDaten" as const, type: "addArrayItem" as const },
+            { target: "list" as const },
+          ],
+          subDaten: "subList" as const,
+          done: null,
+        },
+      });
+
+      const session = createFlowSession(
+        nestedGuardedFlow,
+        {
+          items: [
+            // gate="no" → nested "items" unreachable, but stale entries linger.
+            { name: "a", gate: "no", items: [{ name: "x" }, { name: "y" }] },
+            { name: "b", gate: "yes" },
+          ],
+          pageData: { arrayIndexes: [] },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        "/list",
+      );
+
+      expect(session.prunedUserData).toEqual({
+        items: [{ name: "a", gate: "no" }, { name: "b", gate: "yes" }],
+      });
     });
 
     describe("non-summary addArrayItem fan-out", () => {

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -534,6 +534,71 @@ describe("createFlowSession", () => {
       expect(session.prunedUserData).not.toHaveProperty("pageData");
     });
 
+    describe("non-summary addArrayItem fan-out", () => {
+      // Flow: anzahl -[addArrayItem]-> itemDaten -> anzahl (loop)
+      //             -[fallback]-------> done
+      // "anzahl" has no arraySummary — it is a plain form page that also fans out.
+      const fanOutPages = {
+        anzahl: { stepId: "/anzahl" },
+        itemDaten: {
+          stepId: "/items/#/daten",
+          pageSchema: { label: z.string() },
+        },
+        done: { stepId: "/done" },
+      } as const;
+
+      const fanOutTransitions = {
+        anzahl: [
+          { target: "itemDaten" as const, type: "addArrayItem" as const },
+          { target: "done" as const },
+        ],
+        itemDaten: "anzahl" as const,
+        done: null,
+      };
+
+      const fanOutFlow = compileFlow({
+        pages: fanOutPages,
+        initialStep: "anzahl",
+        transitions: fanOutTransitions,
+      });
+
+      it("add-target is reachable when the array is empty", () => {
+        const session = createFlowSession(fanOutFlow, noData, "/anzahl");
+        expect(session.isReachable("/items/#/daten")).toBe(true);
+      });
+
+      it("item page is reachable when the array has existing entries", () => {
+        const session = createFlowSession(
+          fanOutFlow,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { items: [{ label: "a" }, { label: "b" }], pageData: { arrayIndexes: [] } } as any,
+          "/anzahl",
+        );
+        expect(session.isReachable("/items/#/daten")).toBe(true);
+      });
+
+      it("nextPath skips addArrayItem and returns the fallback target", () => {
+        const session = createFlowSession(fanOutFlow, noData, "/anzahl");
+        expect(session.nextPath).toBe("/done");
+      });
+
+      it("prunedUserData includes array item data via non-summary fan-out", () => {
+        const session = createFlowSession(
+          fanOutFlow,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { items: [{ label: "a" }], pageData: { arrayIndexes: [] } } as any,
+          "/anzahl",
+        );
+        expect(session.prunedUserData).toEqual({ items: [{ label: "a" }] });
+      });
+
+      it("arrayInfo has name but entryPoint is undefined for non-summary nodes", () => {
+        const session = createFlowSession(fanOutFlow, noData, "/anzahl");
+        expect(session.arrayInfo?.name).toBe("items");
+        expect(session.arrayInfo?.entryPoint).toBeUndefined();
+      });
+    });
+
     it("keeps nested array data when the nested array name uses #-notation", () => {
       // Regression test: arraySummary.name like "parents#children" must use the
       // leaf segment ("children") as the scopeData key and arrayPath segment —

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -717,7 +717,10 @@ describe("createFlowSession", () => {
       );
 
       expect(session.prunedUserData).toEqual({
-        items: [{ name: "a", gate: "no" }, { name: "b", gate: "yes" }],
+        items: [
+          { name: "a", gate: "no" },
+          { name: "b", gate: "yes" },
+        ],
       });
     });
 
@@ -758,7 +761,10 @@ describe("createFlowSession", () => {
         const session = createFlowSession(
           fanOutFlow,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          { items: [{ label: "a" }, { label: "b" }], pageData: { arrayIndexes: [] } } as any,
+          {
+            items: [{ label: "a" }, { label: "b" }],
+            pageData: { arrayIndexes: [] },
+          } as any,
           "/anzahl",
         );
         expect(session.isReachable("/items/#/daten")).toBe(true);

--- a/app/services/flow/newFlowEngine/compileFlow.ts
+++ b/app/services/flow/newFlowEngine/compileFlow.ts
@@ -72,6 +72,17 @@ export const compileFlow = <C extends PageConfigMap>({
     >
   > = {};
 
+  // Derives the "#"-notation array name from a target node's stepId.
+  // e.g. "/parents/#/children/#/daten" → "parents#children"
+  const inferArrayNameFromStepId = (stepId: string): string => {
+    const parts = stepId.split("/");
+    const names: string[] = [];
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (parts[i + 1] === ARRAY_WILDCARD) names.push(parts[i]);
+    }
+    return names.join("#");
+  };
+
   // Single-pass static initialization
   for (const [key, pageNode] of Object.entries(pages)) {
     const nodeKey = key as NodeKey<C>;
@@ -87,16 +98,30 @@ export const compileFlow = <C extends PageConfigMap>({
     const { compiledSchema, fieldNames } = normalizeSchema(pageNode.pageSchema);
     schemaCache[nodeKey] = compiledSchema;
     fieldNamesCache[nodeKey] = fieldNames;
+    const nodeTransitions = transitions[nodeKey];
+    const addTransition = Array.isArray(nodeTransitions)
+      ? nodeTransitions.find((t) => t?.type === "addArrayItem")
+      : undefined;
+
     if (pageNode.arraySummary) {
-      const arrayTransitions = transitions[nodeKey];
-      const addTransition = Array.isArray(arrayTransitions)
-        ? arrayTransitions.find((t) => t?.type === "addArrayItem")
-        : undefined;
       arrayInfoCache[nodeKey] = {
         name: pageNode.arraySummary.name,
-        entryPoint: getArrayEntryPoint(arrayTransitions, pages),
+        entryPoint: getArrayEntryPoint(nodeTransitions, pages),
         entryNodeKey: addTransition?.target ?? undefined,
       };
+    } else if (addTransition != null && addTransition.target != null) {
+      // Non-summary node with addArrayItem: populate array info so the BFS
+      // can fan out items. entryPoint is left undefined so callers know not
+      // to render array summary UI for this page.
+      const target = addTransition.target;
+      const name = inferArrayNameFromStepId(pages[target].stepId);
+      if (name) {
+        arrayInfoCache[nodeKey] = {
+          name,
+          entryPoint: undefined,
+          entryNodeKey: target,
+        };
+      }
     }
   }
 

--- a/app/services/flow/newFlowEngine/compileFlow.ts
+++ b/app/services/flow/newFlowEngine/compileFlow.ts
@@ -109,7 +109,7 @@ export const compileFlow = <C extends PageConfigMap>({
         entryPoint: getArrayEntryPoint(nodeTransitions, pages),
         entryNodeKey: addTransition?.target ?? undefined,
       };
-    } else if (addTransition != null && addTransition.target != null) {
+    } else if (addTransition?.target != null) {
       // Non-summary node with addArrayItem: populate array info so the BFS
       // can fan out items. entryPoint is left undefined so callers know not
       // to render array summary UI for this page.

--- a/app/services/flow/newFlowEngine/createFlowSession.ts
+++ b/app/services/flow/newFlowEngine/createFlowSession.ts
@@ -1,4 +1,5 @@
 import { simulate } from "./simulate";
+import { ARRAY_WILDCARD } from "./compileFlow";
 import type { CompiledFlow } from "./compileFlow";
 import type { PageConfigMap, InferredUserData } from "./types";
 import type { PageData } from "../pageDataSchema";
@@ -37,15 +38,55 @@ export const createFlowSession = <C extends PageConfigMap>(
         count: Array.isArray(items) ? items.length : 0,
       };
     },
+    (key) => {
+      const stepId = compiledFlow.pages[key]?.stepId ?? "";
+      return stepId.split(ARRAY_WILDCARD).length - 1;
+    },
   );
 
   // Prev: use the linear breadcrumb so Back returns to the page the user came
   // from, not the BFS shortcut. Fall back to parentMap for off-path pages.
   const keyIndex = simulation.keys.indexOf(nodeKey);
-  const prevNodeKey =
+  const linearPrevNodeKey =
     keyIndex > 0
       ? simulation.keys[keyIndex - 1]
       : simulation.parentMap.get(nodeKey);
+
+  // If the previous page is a bare fan-out node — it hosts the addArrayItem that
+  // reaches the current page but renders no summary of its own — the user never
+  // navigated through it. They used the "add" affordance on the summary that node
+  // exits to (the add button links straight to the item page). Point Back at that
+  // summary instead of the internal fan-out node.
+  const skipFanOutOnlyBack = (candidate: typeof linearPrevNodeKey) => {
+    const seen = new Set<typeof candidate>();
+    let node = candidate;
+    while (node != null && !seen.has(node)) {
+      seen.add(node);
+      const transitions = compiledFlow.transitions[node];
+      if (compiledFlow.pages[node]?.arraySummary || !Array.isArray(transitions))
+        break;
+      const addsCurrent = transitions.some(
+        (t) =>
+          t != null &&
+          typeof t === "object" &&
+          t.type === "addArrayItem" &&
+          t.target === nodeKey,
+      );
+      if (!addsCurrent) break;
+      const fallback = transitions.find(
+        (t) => t != null && typeof t === "object" && t.type !== "addArrayItem",
+      );
+      if (
+        fallback == null ||
+        typeof fallback !== "object" ||
+        fallback.target == null
+      )
+        break;
+      node = fallback.target;
+    }
+    return node;
+  };
+  const prevNodeKey = skipFanOutOnlyBack(linearPrevNodeKey);
 
   // Next: evaluateRoute skips addArrayItem transitions to find the next main-branch step.
   const nextNodeKey =

--- a/app/services/flow/newFlowEngine/simulate.ts
+++ b/app/services/flow/newFlowEngine/simulate.ts
@@ -138,12 +138,14 @@ export const simulate = <C extends PageConfigMap>(
       const targetDepth = getNodeArrayDepth?.(nextBranch) ?? arrayPath.length;
       if (targetDepth < arrayPath.length) {
         const rewoundPath = arrayPath.slice(0, targetDepth);
-        const rewoundIndexes = (pageData.arrayIndexes ?? []).slice(0, targetDepth);
+        const rewoundIndexes = (pageData.arrayIndexes ?? []).slice(
+          0,
+          targetDepth,
+        );
         let rewoundScope = currentData as Record<string, unknown>;
         for (let level = 0; level < targetDepth; level++) {
           const arr = rewoundScope[rewoundPath[level]] as
-            | Array<Record<string, unknown>>
-            | undefined;
+            Array<Record<string, unknown>> | undefined;
           rewoundScope = arr?.[rewoundIndexes[level]] ?? {};
         }
         queue.push({

--- a/app/services/flow/newFlowEngine/simulate.ts
+++ b/app/services/flow/newFlowEngine/simulate.ts
@@ -33,6 +33,10 @@ export const simulate = <C extends PageConfigMap>(
     nodeKey: NodeKey<C>,
     scopeData: Record<string, unknown>,
   ) => { name: string; count: number } | undefined,
+  // A page's array-nesting depth ("/list" = 0, "/items/#/daten" = 1, …).
+  // Lets the BFS rewind its scope pointer when a transition steps back out
+  // to a shallower page.
+  getNodeArrayDepth?: (nodeKey: NodeKey<C>) => number,
 ): SimulationResult & {
   parentMap: Map<NodeKey<C>, NodeKey<C>>;
   visitedContexts: Array<{
@@ -125,7 +129,32 @@ export const simulate = <C extends PageConfigMap>(
     const nextBranch = evaluateRoute(route, itemData);
     if (nextBranch != null) {
       if (!parentMap.has(nextBranch)) parentMap.set(nextBranch, current);
-      queue.push({ key: nextBranch, pageData, scopeData, arrayPath });
+
+      // If the target sits at a shallower array level than the current page,
+      // the transition steps back out of the current item's sub-flow. Rewind
+      // the scope pointer (arrayPath / arrayIndexes / scopeData) to the target's
+      // level so it isn't treated as a nested item — otherwise a shallower array
+      // page would re-fan-out the current item's own children.
+      const targetDepth = getNodeArrayDepth?.(nextBranch) ?? arrayPath.length;
+      if (targetDepth < arrayPath.length) {
+        const rewoundPath = arrayPath.slice(0, targetDepth);
+        const rewoundIndexes = (pageData.arrayIndexes ?? []).slice(0, targetDepth);
+        let rewoundScope = currentData as Record<string, unknown>;
+        for (let level = 0; level < targetDepth; level++) {
+          const arr = rewoundScope[rewoundPath[level]] as
+            | Array<Record<string, unknown>>
+            | undefined;
+          rewoundScope = arr?.[rewoundIndexes[level]] ?? {};
+        }
+        queue.push({
+          key: nextBranch,
+          pageData: { ...pageData, arrayIndexes: rewoundIndexes },
+          scopeData: rewoundScope,
+          arrayPath: rewoundPath,
+        });
+      } else {
+        queue.push({ key: nextBranch, pageData, scopeData, arrayPath });
+      }
     }
 
     // Array branches: fan out once per item. scopeData is narrowed to the


### PR DESCRIPTION
Fix array fanning out in engine
Nodes with an addArrayItem transition but no arraySummary (e.g. a "kinderAnzahl" page) were invisible to the BFS — it never knew to fan out their children. Fix: infer the array name from the target's stepId and store it in arrayInfoCache. entryPoint is left undefined so the route knows not to render array summary UI there.

Back button + scope rewind

Back button: when the previous page in the breadcrumb is a bare fan-out node (no summary), Back used to land the user on that invisible internal page. Now it walks up the transition chain and skips those nodes, pointing Back at the real summary the user came from.
BFS scope rewind: when the BFS follows a transition stepping back to a shallower array level, it now rewinds arrayPath, arrayIndexes, and scopeData to match. Without this, the BFS treated the shallower page as still inside the nested scope and re-fanned-out the current item's children incorrectly. Causing stale nested data to survive pruning.