### PR TITLE
refactor(Array Summary): Add isArrayRelevant function

### DIFF
--- a/app/domains/__test__/pageSchemas.test.ts
+++ b/app/domains/__test__/pageSchemas.test.ts
@@ -257,6 +257,27 @@ describe("filterPageSchemasByReachableSteps", () => {
       ).toBe(false);
     });
 
+    it("should return false if the conditional relevance check fails (isArrayRelevant)", () => {
+      expect(
+        filterPageSchemasByReachableSteps({}, ["/test"], {
+          arrayConfig: {
+            statementKey: "hasKinder",
+            event: "add-kinder",
+            url: "/test",
+            initialInputUrl: "",
+            isArrayRelevant: () => false,
+          },
+        })({
+          stepId: "test",
+          arrayPages: {
+            test: {
+              pageSchema: {},
+            },
+          },
+        } as PageConfig),
+      ).toBe(false);
+    });
+
     it("should return true if a matching array config is found and it satisfies the conditional relevance check (statementKey)", () => {
       expect(
         filterPageSchemasByReachableSteps(
@@ -270,6 +291,33 @@ describe("filterPageSchemasByReachableSteps", () => {
               event: "add-kinder",
               url: "/test",
               initialInputUrl: "",
+            },
+          },
+        )({
+          stepId: "test",
+          arrayPages: {
+            test: {
+              pageSchema: {},
+            },
+          },
+        } as PageConfig),
+      ).toBe(true);
+    });
+
+    it("should return true if a matching array config is found and it satisfies the conditional relevance check (isArrayRelevant)", () => {
+      expect(
+        filterPageSchemasByReachableSteps(
+          {
+            hasKinder: "no",
+          },
+          ["/test"],
+          {
+            arrayConfig: {
+              statementKey: "hasKinder",
+              event: "add-kinder",
+              url: "/test",
+              initialInputUrl: "",
+              isArrayRelevant: () => true,
             },
           },
         )({

--- a/app/domains/pageSchemas.ts
+++ b/app/domains/pageSchemas.ts
@@ -264,7 +264,10 @@ export const filterPageSchemasByReachableSteps =
       );
       const statementKey =
         matchingArrayConfig?.statementKey as keyof typeof userData;
-      return userData[statementKey] === "yes";
+      return (
+        userData[statementKey] === "yes" ||
+        Boolean(matchingArrayConfig?.isArrayRelevant?.(userData as UserData))
+      );
     }
     return (
       "pageSchema" in config && reachableSteps?.includes(`/${config.stepId}`)

--- a/app/services/array/__test__/getArraySummaryData.test.ts
+++ b/app/services/array/__test__/getArraySummaryData.test.ts
@@ -70,6 +70,25 @@ describe("getArraySummaryData", () => {
     ).toEqual({});
   });
 
+  it("filters arrays when isRelevantArray is present and evaluates to false", () => {
+    const arrayConfig = {
+      url: "/beratungshilfe/antrag/finanzielle-angaben/eigentum-zusammenfassung/bankkonten",
+      initialInputUrl: "daten",
+      statementKey: "hasBankkonto",
+      event: addBankkonten,
+      isArrayRelevant: () => false,
+    } as const;
+
+    const summaryData = getArraySummaryData(
+      ["bankkonten"],
+      { bankkonten: arrayConfig },
+      { hasBankkonto: "no" },
+      [],
+    );
+
+    expect(summaryData).toEqual({});
+  });
+
   it("should return disableAddButton false given an undefined function shouldDisableAddButton", () => {
     const actual = getArraySummaryData(
       ["bankkonten"],

--- a/app/services/array/buildArrayConfigServer.ts
+++ b/app/services/array/buildArrayConfigServer.ts
@@ -21,6 +21,7 @@ export const buildArrayConfigServer = (
       url: flowId + targetPath.slice(0, -1).join("/"),
       initialInputUrl: targetPath.at(-1) ?? "",
       statementKey: arrayInfo.fieldName,
+      isArrayRelevant: arrayInfo.isArrayRelevant,
       displayIndexOffset: arrayInfo.indexOffset,
       hiddenFields: arrayInfo.hiddenFields,
     },

--- a/app/services/array/getArraySummaryData.ts
+++ b/app/services/array/getArraySummaryData.ts
@@ -35,7 +35,8 @@ export function getArraySummaryData(
       .filter(
         (category) =>
           category in arrayConfigurations &&
-          userData[arrayConfigurations[category].statementKey] === "yes",
+          (userData[arrayConfigurations[category].statementKey] === "yes" ||
+            Boolean(arrayConfigurations[category].isArrayRelevant?.(userData))),
       )
       .map((category) => {
         const arrayConfiguration = arrayConfigurations[category];

--- a/app/services/array/index.ts
+++ b/app/services/array/index.ts
@@ -9,6 +9,10 @@ export type ArrayConfigServer = {
   url: string;
   initialInputUrl: string;
   statementKey: AllUserDataKeys;
+  /**
+   * statementKey alternative. Used for complex conditionals to display the array summary.
+   */
+  isArrayRelevant?: (context: UserData) => boolean;
   displayIndexOffset?: number;
   shouldDisableAddButton?: (context: UserData) => boolean;
   hiddenFields?: string[];

--- a/app/services/flow/newFlowEngine/compileFlow.ts
+++ b/app/services/flow/newFlowEngine/compileFlow.ts
@@ -1,3 +1,4 @@
+import { type UserData } from "~/domains/userData";
 import { precomputeProgress } from "./precomputeProgress";
 import type { NodeKey, PageConfigMap, TransitionConfigMap } from "./types";
 import z from "zod";
@@ -79,6 +80,7 @@ export const compileFlow = <C extends PageConfigMap>({
         entryPoint?: string;
         entryNodeKey?: NodeKey<C>;
         fieldName?: string;
+        isArrayRelevant?: (userData: UserData) => boolean;
         indexOffset?: number;
         hiddenFields?: string[];
       }
@@ -122,6 +124,7 @@ export const compileFlow = <C extends PageConfigMap>({
         entryPoint: getArrayEntryPoint(nodeTransitions, pages),
         entryNodeKey: addTransition?.target ?? undefined,
         fieldName: pageNode.arraySummary.fieldName,
+        isArrayRelevant: pageNode.arraySummary.isArrayRelevant,
         indexOffset: pageNode.arraySummary.indexOffset,
         hiddenFields: pageNode.arraySummary.hiddenFields,
       };

--- a/app/services/flow/newFlowEngine/types.ts
+++ b/app/services/flow/newFlowEngine/types.ts
@@ -1,5 +1,6 @@
 import { type z } from "zod";
 import type { PageData } from "../pageDataSchema";
+import { type UserData } from "~/domains/userData";
 
 type InferSchema<S> = S extends z.ZodTypeAny
   ? z.infer<S>
@@ -14,7 +15,11 @@ type PageConfig = {
   arraySummary?: {
     name: string;
     schema: z.ZodArray;
+    /**
+     * statementKey
+     */
     fieldName?: string;
+    isArrayRelevant?: (userData: UserData) => boolean;
     indexOffset?: number;
     hiddenFields?: string[];
   };

--- a/app/services/flow/pruner/__test__/pruner.test.ts
+++ b/app/services/flow/pruner/__test__/pruner.test.ts
@@ -1,6 +1,7 @@
 import type { BeratungshilfeFormularUserData } from "~/domains/beratungshilfe/formular/userData";
 import { filterFormFields, pruneIrrelevantData } from "../pruner";
 import * as getAllFieldsFromFlowId from "~/domains/pageSchemas";
+import * as validFormPathsModule from "../validFormPaths";
 
 describe("pruner", () => {
   describe("filterFormFields", () => {
@@ -129,6 +130,51 @@ describe("pruner", () => {
         ],
         pageData: { subflowDoneStates: { "/a": true } },
       });
+    });
+
+    it("keeps array fields when valid paths include an array page", () => {
+      const getFieldsSpy = vi
+        .spyOn(getAllFieldsFromFlowId, "getAllFieldsFromFlowId")
+        .mockReturnValue({
+          "/start": ["hasBankkonto"],
+          "/bankkonten/bankkonto/daten": ["bankkonten#kontoEigentuemer"],
+        });
+
+      const validPathsSpy = vi
+        .spyOn(validFormPathsModule, "validFormPaths")
+        .mockReturnValue([
+          { stepIds: ["/start"] },
+          {
+            stepIds: ["/bankkonten/bankkonto/daten"],
+            arrayIndex: 0,
+          },
+        ]);
+
+      const userData = {
+        hasBankkonto: "no",
+        "bankkonten[0]kontoEigentuemer": "myself",
+        irrelevant: "remove-me",
+      };
+
+      const { prunedData, validFlowPaths } = pruneIrrelevantData(
+        userData,
+        "/beratungshilfe/antrag",
+      );
+
+      expect(validPathsSpy).toHaveBeenCalled();
+
+      expect(prunedData).toStrictEqual({
+        hasBankkonto: "no",
+        "bankkonten[0]kontoEigentuemer": "myself",
+      });
+
+      expect(validFlowPaths).toEqual({
+        "/start": { isArrayPage: false },
+        "/bankkonten/bankkonto/daten": { isArrayPage: true },
+      });
+
+      getFieldsSpy.mockRestore();
+      validPathsSpy.mockRestore();
     });
   });
 

--- a/app/services/flow/pruner/__test__/validFormPaths.test.ts
+++ b/app/services/flow/pruner/__test__/validFormPaths.test.ts
@@ -1,6 +1,7 @@
 import type { BeratungshilfeFormularUserData } from "~/domains/beratungshilfe/formular/userData";
 import { flows } from "~/domains/flows.server";
 import { buildFlowController } from "../../server/buildFlowController";
+import type { Config } from "../../server/types";
 import { validFormPaths } from "../validFormPaths";
 
 describe("validFormPaths", () => {
@@ -117,6 +118,74 @@ describe("validFormPaths", () => {
       };
       const validPaths = validFormPaths(buildFlowController({ config, data }));
       expect(validPaths.length).toStrictEqual(1);
+    });
+
+    it("includes arrays when isArrayRelevant returns true even if statement key is not 'yes'", () => {
+      const data: BeratungshilfeFormularUserData = {
+        hasBankkonto: "no",
+        wurdeVerklagt: "no",
+        bankkonten: [
+          {
+            kontoEigentuemer: "myself",
+            bankName: "FooBank",
+            kontostand: "199,00",
+            iban: "",
+          },
+        ],
+      };
+
+      const minimalConfig = {
+        id: "/beratungshilfe/antrag",
+        initial: "summary",
+        meta: {
+          arrays: {
+            bankkonten: {
+              event: "add-bankkonten",
+              url: "/beratungshilfe/antrag/summary/bankkonten",
+              initialInputUrl: "daten",
+              statementKey: "hasBankkonto",
+              isArrayRelevant: (context: BeratungshilfeFormularUserData) =>
+                context.wurdeVerklagt === "no",
+            },
+          },
+        },
+        states: {
+          summary: {
+            id: "summary",
+            initial: "overview",
+            states: {
+              overview: {
+                on: {
+                  SUBMIT: "done",
+                  "add-bankkonten": "bankkonten",
+                },
+              },
+              bankkonten: {
+                initial: "daten",
+                states: {
+                  daten: {
+                    on: {
+                      SUBMIT: "ende",
+                      BACK: "#summary.overview",
+                    },
+                  },
+                  ende: {},
+                },
+              },
+              done: {},
+            },
+          },
+        },
+      } satisfies Config;
+
+      const validPaths = validFormPaths(
+        buildFlowController({ config: minimalConfig, data }),
+      );
+
+      expect(validPaths).toContainEqual({
+        stepIds: ["/summary/bankkonten/daten", "/summary/bankkonten/ende"],
+        arrayIndex: 0,
+      });
     });
   });
 });

--- a/app/services/flow/pruner/validFormPaths.ts
+++ b/app/services/flow/pruner/validFormPaths.ts
@@ -38,7 +38,9 @@ function getSubflowPaths(flowController: FlowController): Path[] {
   return Object.entries(flowController.getRootMeta()?.arrays ?? {})
     .filter(
       ([key, arrayConfig]) =>
-        userData[key] && userData[arrayConfig.statementKey] === "yes",
+        userData[key] &&
+        (userData[arrayConfig.statementKey] === "yes" ||
+          Boolean(arrayConfig.isArrayRelevant?.(userData))),
     )
     .filter(([_key, arrayConfig]) => {
       // Filter arrays who's first step is not reachable from the main flow


### PR DESCRIPTION
This PR introduces a novel arrayConfiguration property, isArrayRelevant, that allows for more complex conditional array summary logic. Previously, the array summary would only be displayed based on a statementKey, or, a UserData yes/no property that can be evaluated as a boolean. In the Nachlass Erbscheinsanfrage flow, we need to display the Beguetigste Array if one of several enum values are detected.
