### PR TITLE
APL-2292 array summary prevpath fix

### DIFF
--- a/app/domains/__test__/flowSchemaNewEngine.test.ts
+++ b/app/domains/__test__/flowSchemaNewEngine.test.ts
@@ -17,6 +17,13 @@ import { geldEinklagenFormularTestCases } from "../geldEinklagen/formular/__test
 import { kontopfaendungWegweiserTestCases } from "../kontopfaendung/wegweiser/__test__/testcasesWithUserInputs";
 import { nachlassErbscheinAnfrageTestCases } from "~/domains/nachlass/erbschein/anfrage/__test__/testCasesWithUserInput";
 
+// Back from a page can point at a completed array item: the engine resolves
+// that to a concrete path ("/angehoerige/0/x"), while the testcase still
+// declares it with the array wildcard ("/angehoerige/#/x"). Normalize "#" to
+// a digit first so the existing removeArrayIndex() strips both forms the same way.
+const normalizePrevPath = (path: string) =>
+  removeArrayIndex(path.replaceAll("#", "0"));
+
 const flowSchemaTests = {
   geldEinklagenFormularTestCases,
   nachlassErbscheinAnfrageTestCases,
@@ -182,16 +189,9 @@ function runTestcases<T extends UserData>(
           } else {
             expect(flowSessionEngine.nextPath).toBe(nextStepId);
 
-            // Back from a page can point at a completed array item: the engine
-            // resolves that to a concrete path ("/angehoerige/0/x"), while the
-            // testcase still declares it with the array wildcard
-            // ("/angehoerige/#/x"). Normalize "#" to a digit first so the
-            // existing removeArrayIndex() strips both forms the same way.
             if (idx > 0 && previousStepId !== undefined) {
-              const normalize = (path: string) =>
-                removeArrayIndex(path.replaceAll("#", "0"));
-              expect(normalize(flowSessionEngine.prevPath ?? "")).toBe(
-                normalize(previousStepId),
+              expect(normalizePrevPath(flowSessionEngine.prevPath ?? "")).toBe(
+                normalizePrevPath(previousStepId),
               );
             }
           }

--- a/app/domains/__test__/flowSchemaNewEngine.test.ts
+++ b/app/domains/__test__/flowSchemaNewEngine.test.ts
@@ -182,8 +182,17 @@ function runTestcases<T extends UserData>(
           } else {
             expect(flowSessionEngine.nextPath).toBe(nextStepId);
 
+            // Back from a page can point at a completed array item: the engine
+            // resolves that to a concrete path ("/angehoerige/0/x"), while the
+            // testcase still declares it with the array wildcard
+            // ("/angehoerige/#/x"). Normalize "#" to a digit first so the
+            // existing removeArrayIndex() strips both forms the same way.
             if (idx > 0 && previousStepId !== undefined) {
-              expect(flowSessionEngine.prevPath).toBe(previousStepId);
+              const normalize = (path: string) =>
+                removeArrayIndex(path.replaceAll("#", "0"));
+              expect(normalize(flowSessionEngine.prevPath ?? "")).toBe(
+                normalize(previousStepId),
+              );
             }
           }
 

--- a/app/domains/nachlass/erbschein/anfrage/angehoerige/__test__/prevPath.test.ts
+++ b/app/domains/nachlass/erbschein/anfrage/angehoerige/__test__/prevPath.test.ts
@@ -1,0 +1,53 @@
+import { createFlowSession } from "~/services/flow/newFlowEngine/createFlowSession";
+import { nachlassErbscheinAnfrageFlowConfig } from "~/domains/nachlass/erbschein/anfrage/flowConfig";
+
+const happyPathData = {
+  datenverarbeitungZustimmung: "on",
+  verstorbenePersonStrasse: "Musterstraße",
+  verstorbenePersonHausnummer: "1",
+  verstorbenePersonOrt: "Musterstadt",
+  antragstellendePersonTelefonnummer: "0123456789",
+  testamentArt: "none",
+  verstorbeneFamilienstand: "ledig",
+};
+
+type UserData = Parameters<typeof createFlowSession>[1];
+
+describe("angehoerigeOverview Back navigation", () => {
+  it("resolves a concrete prevPath after one deceased Angehoerige was filled in", () => {
+    const session = createFlowSession(
+      nachlassErbscheinAnfrageFlowConfig,
+      {
+        ...happyPathData,
+        angehoerige: [
+          {
+            vorname: "Max",
+            nachname: "Mustermann",
+            geburtsdatum: { day: "01", month: "01", year: "1990" },
+            geburtsort: "Musterstadt",
+            isAlive: "no",
+            sterbedatum: { day: "01", month: "01", year: "2020" },
+            sterbeort: "Musterstadt",
+          },
+        ],
+        pageData: { arrayIndexes: [] },
+      } as UserData,
+      "/angehoerige/uebersicht",
+    );
+
+    expect(session.prevPath).toBe("/angehoerige/0/sterbedatum");
+  });
+
+  it("does not leak an unresolved array wildcard when no Angehoerige was ever submitted", () => {
+    const session = createFlowSession(
+      nachlassErbscheinAnfrageFlowConfig,
+      {
+        ...happyPathData,
+        pageData: { arrayIndexes: [] },
+      } as UserData,
+      "/angehoerige/uebersicht",
+    );
+
+    expect(session.prevPath).not.toContain("#");
+  });
+});

--- a/app/domains/nachlass/erbschein/erbfolge/__test__/prevPath.test.ts
+++ b/app/domains/nachlass/erbschein/erbfolge/__test__/prevPath.test.ts
@@ -1,0 +1,57 @@
+import { createFlowSession } from "~/services/flow/newFlowEngine/createFlowSession";
+import { nachlassErbfolgeStaticFlow } from "../flowConfig";
+
+type UserData = Parameters<typeof createFlowSession>[1];
+
+describe("erbfolge Back navigation across array-summary cycles", () => {
+  it("resolves a concrete prevPath from kind1Summary after one kind was filled in", () => {
+    const session = createFlowSession(
+      nachlassErbfolgeStaticFlow,
+      {
+        hatteKinder: "yes",
+        kinder: [{ name: "Kind 1", isAlive: "yes" }],
+        elternteile: [],
+        pageData: { arrayIndexes: [] },
+      } as UserData,
+      "/kinder",
+    );
+
+    expect(session.prevPath).toBe("/kinder/0/daten");
+  });
+
+  it("resolves a concrete prevPath from kind1Summary through a nested grandchild cycle", () => {
+    const session = createFlowSession(
+      nachlassErbfolgeStaticFlow,
+      {
+        hatteKinder: "yes",
+        kinder: [
+          {
+            name: "Kind 1",
+            isAlive: "no",
+            hatteKinder: "yes",
+            kinder: [{ name: "Enkel", isAlive: "yes" }],
+          },
+        ],
+        elternteile: [],
+        pageData: { arrayIndexes: [] },
+      } as UserData,
+      "/kinder",
+    );
+
+    expect(session.prevPath).toBe("/kinder/0/daten");
+  });
+
+  it("resolves a concrete prevPath from elternteilSummary after one Elternteil was filled in", () => {
+    const session = createFlowSession(
+      nachlassErbfolgeStaticFlow,
+      {
+        hatteKinder: "no",
+        elternteile: [{ name: "Elternteil A", isAlive: "yes" }],
+        pageData: { arrayIndexes: [] },
+      } as UserData,
+      "/elternteile",
+    );
+
+    expect(session.prevPath).toBe("/elternteile/0/daten");
+  });
+});

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -549,6 +549,44 @@ describe("createFlowSession", () => {
 
         expect(session.prevPath).toBe("/parents/0/children/0/detail");
       });
+
+      it("falls back to the first occurrence when the array is empty (add started but nothing submitted)", () => {
+        const arrayCompleteFlow = compileFlow({
+          pages: {
+            start: { stepId: "/start" },
+            overview: {
+              stepId: "/items",
+              arraySummary: {
+                name: "entries",
+                schema: z.array(z.object({ name: z.string() })),
+              },
+            },
+            itemDetail: {
+              stepId: "/items/#/detail",
+              pageSchema: { "entries#name": z.string() },
+            },
+            done: { stepId: "/done" },
+          },
+          initialStep: "start",
+          transitions: {
+            start: "overview",
+            overview: [
+              { target: "itemDetail", type: "addArrayItem" },
+              { target: "done" },
+            ],
+            itemDetail: "overview",
+            done: null,
+          },
+        });
+
+        const session = createFlowSession(
+          arrayCompleteFlow,
+          { pageData: { arrayIndexes: [] } } as any,
+          "/items",
+        );
+
+        expect(session.prevPath).toBe("/start");
+      });
     });
   });
 

--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -449,8 +449,105 @@ describe("createFlowSession", () => {
           "/items",
         );
 
-        // Back from the second overview should go to the item page (last occurrence)
-        expect(session.prevPath).toBe("/items/#/detail");
+        // Back from the second overview should go to the item page (last occurrence),
+        // with a concrete index — the overview page itself has no array index of its
+        // own to fall back on, so a bare "#" template would be unusable by callers.
+        expect(session.prevPath).toBe("/items/0/detail");
+      });
+
+      it("resolves the last completed item's own index, not always index 0", () => {
+        const arrayCompleteFlow = compileFlow({
+          pages: {
+            overview: {
+              stepId: "/items",
+              arraySummary: {
+                name: "entries",
+                schema: z.array(z.object({ name: z.string() })),
+              },
+            },
+            itemDetail: {
+              stepId: "/items/#/detail",
+              pageSchema: { "entries#name": z.string() },
+            },
+            done: { stepId: "/done" },
+          },
+          initialStep: "overview",
+          transitions: {
+            overview: [
+              { target: "itemDetail", type: "addArrayItem" },
+              { target: "done" },
+            ],
+            itemDetail: "overview",
+            done: null,
+          },
+        });
+
+        const session = createFlowSession(
+          arrayCompleteFlow,
+          {
+            entries: [{ name: "first entry" }, { name: "second entry" }],
+            pageData: { arrayIndexes: [] },
+          } as any,
+          "/items",
+        );
+
+        expect(session.prevPath).toBe("/items/1/detail");
+      });
+
+      // Mirrors a real-world shape: a 0-wildcard array-summary page cycling
+      // through a *nested* array item (2 wildcards) before falling back to the
+      // summary. The picked predecessor sits two levels deeper than the current
+      // page, so both wildcards must be resolved, not just the first.
+      it("resolves concrete indexes for a nested (multi-wildcard) cycle predecessor", () => {
+        const nestedArrayFlow = compileFlow({
+          pages: {
+            overview: {
+              stepId: "/parents",
+              arraySummary: {
+                name: "parents",
+                schema: z.array(
+                  z.object({
+                    name: z.string(),
+                    children: z.array(z.object({ name: z.string() })),
+                  }),
+                ),
+              },
+            },
+            parentDetail: {
+              stepId: "/parents/#/detail",
+              pageSchema: { "parents#name": z.string() },
+            },
+            childDetail: {
+              stepId: "/parents/#/children/#/detail",
+              pageSchema: { "parents#children#name": z.string() },
+            },
+            done: { stepId: "/done" },
+          },
+          initialStep: "overview",
+          transitions: {
+            overview: [
+              { target: "parentDetail", type: "addArrayItem" },
+              { target: "done" },
+            ],
+            parentDetail: [
+              { target: "childDetail", type: "addArrayItem" },
+              { target: "overview" },
+            ],
+            childDetail: "overview",
+            done: null,
+          },
+        });
+
+        const session = createFlowSession(
+          nestedArrayFlow,
+          {
+            parents: [{ name: "Parent 1", children: [{ name: "Child 1" }] }],
+            pageData: { arrayIndexes: [] },
+          } as any,
+          "/parents",
+        );
+
+        expect(session.prevPath).toBe("/parents/0/children/0/detail");
       });
     });
   });

--- a/app/services/flow/newFlowEngine/createFlowSession.ts
+++ b/app/services/flow/newFlowEngine/createFlowSession.ts
@@ -11,6 +11,16 @@ import { pruneUserData } from "./pruneUserData";
 const resolveFieldName = (fieldName: string) =>
   fieldName.includes("#") ? fieldName.split("#").at(-1)! : fieldName;
 
+const arrayWildcardCount = (stepId: string) =>
+  stepId.split(ARRAY_WILDCARD).length - 1;
+
+// Substitutes each array wildcard in a stepId with a concrete index, in
+// left-to-right order (e.g. "/a/#/b/#/c" + [0, 2] -> "/a/0/b/2/c").
+const insertConcreteIndexes = (stepId: string, indexes: number[]) => {
+  let index = 0;
+  return stepId.replaceAll(ARRAY_WILDCARD, () => String(indexes[index++]));
+};
+
 export const createFlowSession = <C extends PageConfigMap>(
   compiledFlow: CompiledFlow<C>,
   userData: InferredUserData<C> & { pageData: PageData },
@@ -179,6 +189,46 @@ export const createFlowSession = <C extends PageConfigMap>(
     return node;
   };
   const prevNodeKey = skipFanOutOnlyBack(linearPrevNodeKey);
+
+  // The chosen prevNodeKey can sit deeper in array nesting than the current
+  // page (e.g. Back from a 0-wildcard array-summary page picked the last
+  // completed item's page, which has 1+ wildcards). The current page's own
+  // arrayIndexes can't fill those in — there's nothing at that depth to read.
+  // Resolve concrete indexes from the real (index-aware) visited context
+  // instead, so prevPath is always directly usable, never a bare "#" template.
+  const resolvePrevPath = (): string | undefined => {
+    if (prevNodeKey == null) return undefined;
+    const prevStepId = compiledFlow.pages[prevNodeKey]?.stepId;
+    if (prevStepId == null) return undefined;
+
+    const currentStepId = compiledFlow.pages[nodeKey]?.stepId ?? "";
+    if (arrayWildcardCount(prevStepId) <= arrayWildcardCount(currentStepId)) {
+      return compiledFlow.getPathFromNodeKey(
+        prevNodeKey as Extract<keyof C, string>,
+      );
+    }
+
+    // Most recently completed instance of that page wins (mirrors "last
+    // occurrence" cycle selection above).
+    const match = [...simulation.visitedContexts]
+      .reverse()
+      .find(
+        ({ key, scopeData }) =>
+          key === prevNodeKey &&
+          isPageDone(
+            compiledFlow.getSchemaByNodeKey(key),
+            compiledFlow.getFieldNamesByNodeKey(key),
+            scopeData as Record<string, unknown>,
+          ),
+      );
+    if (!match) {
+      return compiledFlow.getPathFromNodeKey(
+        prevNodeKey as Extract<keyof C, string>,
+      );
+    }
+    return insertConcreteIndexes(prevStepId, match.pageData.arrayIndexes ?? []);
+  };
+
   return {
     nodeKey,
     pageSchema: compiledFlow.getSchema(currentPath),
@@ -208,9 +258,7 @@ export const createFlowSession = <C extends PageConfigMap>(
         true,
       ) ?? undefined,
     ),
-    prevPath: compiledFlow.getPathFromNodeKey(
-      prevNodeKey as Extract<keyof C, string>,
-    ),
+    prevPath: resolvePrevPath(),
     isArrayPage: (path: string): boolean => {
       return compiledFlow.getArrayInfo(path) !== undefined;
     },

--- a/app/services/flow/newFlowEngine/createFlowSession.ts
+++ b/app/services/flow/newFlowEngine/createFlowSession.ts
@@ -125,42 +125,15 @@ export const createFlowSession = <C extends PageConfigMap>(
       .map(({ key }) => key),
   );
 
-  // When nodeKey appears multiple times (a cycle), pick the right occurrence:
-  // redirect loops use first, array-complete cycles use last (if intermediate pages are filled).
-  const selectCycleOccurrence = (
-    keys: string[],
-    key: string,
-    done: Set<string>,
-  ): number => {
-    const first = keys.indexOf(key);
-    const last = keys.lastIndexOf(key);
-    if (first === last) return first;
-    const intermediates = keys.slice(first + 1, last).filter((k) => k !== key);
-    const hasFilled = intermediates.some(
-      (k) =>
-        compiledFlow.getFieldNamesByNodeKey(k as Extract<keyof C, string>)
-          .length > 0 && done.has(k as Extract<keyof C, string>),
-    );
-    return hasFilled ? last : first;
-  };
-
-  const keyIndex = selectCycleOccurrence(
-    simulation.keys,
-    nodeKey,
-    doneNodeKeys,
-  );
-  const linearPrevNodeKey =
-    keyIndex > 0
-      ? simulation.keys[keyIndex - 1]
-      : simulation.parentMap.get(nodeKey);
-
   // If the previous page is a bare fan-out node — it hosts the addArrayItem that
   // reaches the current page but renders no summary of its own — the user never
   // navigated through it. They used the "add" affordance on the summary that node
   // exits to (the add button links straight to the item page). Point Back at that
   // summary instead of the internal fan-out node.
-  const skipFanOutOnlyBack = (candidate: typeof linearPrevNodeKey) => {
-    const seen = new Set<typeof candidate>();
+  const skipFanOutOnlyBack = (
+    candidate: Extract<keyof C, string> | undefined,
+  ): Extract<keyof C, string> | undefined => {
+    const seen = new Set<Extract<keyof C, string> | undefined>();
     let node = candidate;
     while (node != null && !seen.has(node)) {
       seen.add(node);
@@ -188,46 +161,71 @@ export const createFlowSession = <C extends PageConfigMap>(
     }
     return node;
   };
-  const prevNodeKey = skipFanOutOnlyBack(linearPrevNodeKey);
 
-  // The chosen prevNodeKey can sit deeper in array nesting than the current
-  // page (e.g. Back from a 0-wildcard array-summary page picked the last
-  // completed item's page, which has 1+ wildcards). The current page's own
-  // arrayIndexes can't fill those in — there's nothing at that depth to read.
-  // Resolve concrete indexes from the real (index-aware) visited context
-  // instead, so prevPath is always directly usable, never a bare "#" template.
-  const resolvePrevPath = (): string | undefined => {
-    if (prevNodeKey == null) return undefined;
-    const prevStepId = compiledFlow.pages[prevNodeKey]?.stepId;
+  const prevNodeKeyAtIndex = (index: number) => {
+    const linear =
+      index > 0
+        ? (simulation.keys[index - 1] as Extract<keyof C, string> | undefined)
+        : simulation.parentMap.get(nodeKey);
+    return skipFanOutOnlyBack(linear);
+  };
+
+  // Resolves a candidate predecessor to a directly usable path, or null if it
+  // sits deeper in array nesting than the current page and no real (index-aware)
+  // visited context exists to fill in the extra wildcards from — the current
+  // page's own arrayIndexes can't help, there's nothing at that depth to read.
+  const resolveConcretePrevPath = (
+    candidate: Extract<keyof C, string> | undefined,
+  ): string | undefined | null => {
+    if (candidate == null) return undefined;
+    const prevStepId = compiledFlow.pages[candidate]?.stepId;
     if (prevStepId == null) return undefined;
 
     const currentStepId = compiledFlow.pages[nodeKey]?.stepId ?? "";
     if (arrayWildcardCount(prevStepId) <= arrayWildcardCount(currentStepId)) {
-      return compiledFlow.getPathFromNodeKey(
-        prevNodeKey as Extract<keyof C, string>,
-      );
+      return compiledFlow.getPathFromNodeKey(candidate);
     }
 
-    // Most recently completed instance of that page wins (mirrors "last
-    // occurrence" cycle selection above).
-    const match = [...simulation.visitedContexts]
-      .reverse()
-      .find(
+    // Prefer the most recently completed instance of that page; fall back to
+    // the most recently visited one (any state) so partial data still resolves.
+    const visited = [...simulation.visitedContexts].reverse();
+    const match =
+      visited.find(
         ({ key, scopeData }) =>
-          key === prevNodeKey &&
+          key === candidate &&
           isPageDone(
             compiledFlow.getSchemaByNodeKey(key),
             compiledFlow.getFieldNamesByNodeKey(key),
             scopeData as Record<string, unknown>,
           ),
-      );
-    if (!match) {
-      return compiledFlow.getPathFromNodeKey(
-        prevNodeKey as Extract<keyof C, string>,
-      );
-    }
+      ) ?? visited.find(({ key }) => key === candidate);
+    if (!match) return null;
     return insertConcreteIndexes(prevStepId, match.pageData.arrayIndexes ?? []);
   };
+
+  // When nodeKey appears multiple times (a cycle), prefer the last occurrence
+  // for array-complete cycles (intermediate pages filled), first for redirect
+  // loops. But the "last" pick is only safe if it actually resolves to a
+  // concrete path — if there's no real data to back it (e.g. the user started
+  // an item but never got far enough for anything to be "done"), fall back to
+  // the first occurrence instead of ever surfacing an unresolvable "#" template.
+  const first = simulation.keys.indexOf(nodeKey);
+  const last = simulation.keys.lastIndexOf(nodeKey);
+  const intermediates =
+    first === last
+      ? []
+      : simulation.keys.slice(first + 1, last).filter((k) => k !== nodeKey);
+  const hasFilled = intermediates.some(
+    (k) =>
+      compiledFlow.getFieldNamesByNodeKey(k as Extract<keyof C, string>)
+        .length > 0 && doneNodeKeys.has(k as Extract<keyof C, string>),
+  );
+
+  const prevPath = hasFilled
+    ? (resolveConcretePrevPath(prevNodeKeyAtIndex(last)) ??
+      resolveConcretePrevPath(prevNodeKeyAtIndex(first)) ??
+      undefined)
+    : (resolveConcretePrevPath(prevNodeKeyAtIndex(first)) ?? undefined);
 
   return {
     nodeKey,
@@ -258,7 +256,7 @@ export const createFlowSession = <C extends PageConfigMap>(
         true,
       ) ?? undefined,
     ),
-    prevPath: resolvePrevPath(),
+    prevPath,
     isArrayPage: (path: string): boolean => {
       return compiledFlow.getArrayInfo(path) !== undefined;
     },


### PR DESCRIPTION
**Root cause:** createFlowSession.ts's "last occurrence" cycle logic (added in b72ad0c21 for the new angehoerige sub-flow) could pick a prevPath that requires more array indices than the current page provides — e.g. Back from a 0-index array-summary page resolving to a still-templated # path. No caller could safely turn that into a real URL; erbfolge's route crashed on it via resolveArrayCharacter's invariant.

**Fix:** when the picked predecessor needs more array depth than the current page, resolve concrete indices from the real (index-aware) visited context instead of returning a bare wildcard template.