### PR TITLE
fix(Auto Generated Summary): Preserve stepStates order

### DIFF
--- a/app/services/summary/__test__/autoGenerateSummary.test.ts
+++ b/app/services/summary/__test__/autoGenerateSummary.test.ts
@@ -277,6 +277,21 @@ describe("generateSummaryFromUserData", () => {
       });
     });
 
+    it("should preserve the semantic order of sections based on stepStates", async () => {
+      const rearrangedUserData = Object.fromEntries(
+        Object.entries(mockUserData).reverse(),
+      );
+      const result = await generateSummaryFromUserData(
+        rearrangedUserData,
+        mockFlowId,
+        mockStepStates,
+        mockTranslations,
+      );
+
+      const sectionIds = result.map((section) => section.id);
+      expect(sectionIds).toEqual(["persoenliche-daten", "finanzielle-angaben"]);
+    });
+
     it("should handle empty fields with 'Keine Angabe'", async () => {
       const userDataWithEmpty: UserData = {
         vorname: "Max",

--- a/app/services/summary/autoGenerateSummary.ts
+++ b/app/services/summary/autoGenerateSummary.ts
@@ -113,5 +113,14 @@ export async function generateSummaryFromUserData(
     sections.push(section);
   }
 
+  const stepOrder = new Map(
+    stepStates.map((s, i) => [s.stepId.replace(/^\//, ""), i]),
+  );
+  sections.sort(
+    (a, b) =>
+      (stepOrder.get(String(a.id)) ?? Infinity) -
+      (stepOrder.get(String(b.id)) ?? Infinity),
+  );
+
   return sections;
 }

--- a/app/services/summary/autoGenerateSummary.ts
+++ b/app/services/summary/autoGenerateSummary.ts
@@ -116,11 +116,10 @@ export async function generateSummaryFromUserData(
   const stepOrder = new Map(
     stepStates.map((s, i) => [s.stepId.replace(/^\//, ""), i]),
   );
-  sections.sort(
+
+  return sections.toSorted(
     (a, b) =>
       (stepOrder.get(String(a.id)) ?? Infinity) -
       (stepOrder.get(String(b.id)) ?? Infinity),
   );
-
-  return sections;
 }


### PR DESCRIPTION
Previously, the display order of the auto-generated summary was arbitrarily based on the order in which userData keys appear. Now, it's sorted according to the semantic order of stepStates, ensuring a more logical user experience.
