### PR TITLE
fan out each addArrayItem to its own array

### DIFF
--- a/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
+++ b/app/services/flow/newFlowEngine/__test__/createFlowSession.test.ts
@@ -532,6 +532,86 @@ describe("createFlowSession", () => {
     });
   });
 
+  describe("sibling arrays on one item node", () => {
+    // One item page adds to two nested arrays ("docs" and "people").
+    // Each must fan out under its own name, so both add pages stay reachable.
+    const buildSiblingArraysFlow = () =>
+      compileFlow({
+        pages: {
+          list: {
+            stepId: "/list",
+            arraySummary: {
+              name: "items",
+              schema: z.array(
+                z.object({
+                  docs: z.array(z.object({ label: z.string() })).optional(),
+                  people: z.array(z.object({ name: z.string() })).optional(),
+                }),
+              ),
+            },
+          },
+          itemDaten: {
+            stepId: "/items/#/daten",
+            pageSchema: { "items#gate": z.string() },
+          },
+          docAdd: {
+            stepId: "/items/#/docs/#/daten",
+            pageSchema: { "items#docs#label": z.string() },
+          },
+          peopleAdd: {
+            stepId: "/items/#/people/#/daten",
+            pageSchema: { "items#people#name": z.string() },
+          },
+          done: { stepId: "/done" },
+        },
+        initialStep: "list",
+        transitions: {
+          list: [
+            { target: "itemDaten" as const, type: "addArrayItem" as const },
+            { target: "done" as const },
+          ],
+          itemDaten: [
+            { target: "docAdd" as const, type: "addArrayItem" as const },
+            { target: "peopleAdd" as const, type: "addArrayItem" as const },
+            { target: "list" as const },
+          ],
+          docAdd: "list" as const,
+          peopleAdd: "list" as const,
+          done: null,
+        },
+      });
+
+    it("makes both sibling add-targets reachable when the item has no sub-items yet", () => {
+      const flowWithSiblings = buildSiblingArraysFlow();
+      const session = createFlowSession(
+        flowWithSiblings,
+        {
+          items: [{}],
+          pageData: { arrayIndexes: [0] },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        "/list",
+      );
+      expect(session.isReachable("/items/#/docs/#/daten")).toBe(true);
+      expect(session.isReachable("/items/#/people/#/daten")).toBe(true);
+    });
+
+    it("makes the second sibling add-target reachable when the first array already has items", () => {
+      const flowWithSiblings = buildSiblingArraysFlow();
+      const session = createFlowSession(
+        flowWithSiblings,
+        {
+          items: [{ docs: [{ label: "a" }, { label: "b" }] }],
+          pageData: { arrayIndexes: [0] },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        "/list",
+      );
+      // people is still empty, so its add page is the first item
+      expect(session.isReachable("/items/#/people/#/daten")).toBe(true);
+    });
+  });
+
   describe("arrayInfo", () => {
     it("returns undefined for non-array pages", () => {
       const session = createFlowSession(flow, noData, "/start");

--- a/app/services/flow/newFlowEngine/compileFlow.ts
+++ b/app/services/flow/newFlowEngine/compileFlow.ts
@@ -7,6 +7,15 @@ import z from "zod";
 // Defined locally to keep the engine decoupled from the app's array service.
 export const ARRAY_WILDCARD = "#";
 
+// Array name from a stepId's "#" segments.
+// "/parents/#/children/#/daten" gives "parents#children".
+export const inferArrayNameFromStepId = (stepId: string): string => {
+  const segments = stepId.split("/");
+  return segments
+    .filter((_, index) => segments[index + 1] === ARRAY_WILDCARD)
+    .join("#");
+};
+
 // "singlePass" prunes against the current data once. "cascading" re-prunes
 // until stable, so pages kept alive only by stale fields also fall off.
 type PruningStrategy = "singlePass" | "cascading";
@@ -87,17 +96,6 @@ export const compileFlow = <C extends PageConfigMap>({
     >
   > = {};
 
-  // Derives the "#"-notation array name from a target node's stepId.
-  // e.g. "/parents/#/children/#/daten" → "parents#children"
-  const inferArrayNameFromStepId = (stepId: string): string => {
-    const parts = stepId.split("/");
-    const names: string[] = [];
-    for (let i = 0; i < parts.length - 1; i++) {
-      if (parts[i + 1] === ARRAY_WILDCARD) names.push(parts[i]);
-    }
-    return names.join("#");
-  };
-
   // Single-pass static initialization
   for (const [key, pageNode] of Object.entries(pages)) {
     const nodeKey = key as NodeKey<C>;
@@ -177,7 +175,6 @@ export const compileFlow = <C extends PageConfigMap>({
       fieldNamesCache[nodeKey] ?? [],
     getSchemaByNodeKey: (nodeKey: NodeKey<C>): z.ZodTypeAny | undefined =>
       schemaCache[nodeKey],
-    getArrayInfoByNodeKey: (nodeKey: NodeKey<C>) => arrayInfoCache[nodeKey],
 
     getNodeKeyFromPath,
     getPathFromNodeKey,

--- a/app/services/flow/newFlowEngine/simulate.ts
+++ b/app/services/flow/newFlowEngine/simulate.ts
@@ -8,6 +8,7 @@ import type {
 import type { PageData } from "../pageDataSchema";
 import {
   ARRAY_WILDCARD,
+  inferArrayNameFromStepId,
   type CompiledFlow,
 } from "~/services/flow/newFlowEngine/compileFlow";
 
@@ -37,18 +38,21 @@ export const runSimulation = <C extends PageConfigMap>(
     compiledFlow.initialStep,
     data,
     true,
-    (key, scopeData) => {
-      const info = compiledFlow.getArrayInfoByNodeKey(key);
-      if (!info) return undefined;
-      // info.name uses "#" notation (e.g. "children#children") but scopeData
-      // is already scoped to the current item, so the real property key is
-      // just the last segment after "#" (e.g. "children").
-      const leafName = info.name.split("#").at(-1)!;
+    (sourceKey, targetKey, scopeData) => {
+      // Which array does this fan-out add to?
+      // Summary pages name it directly; others read it from the target's stepId.
+      // Reading the target lets one page add to several arrays.
+      const name =
+        compiledFlow.pages[sourceKey]?.arraySummary?.name ??
+        inferArrayNameFromStepId(compiledFlow.pages[targetKey]?.stepId ?? "");
+      if (!name) return undefined;
+      // scopeData is already the current item, so the key is the last "#" segment.
+      const leafName = name.split("#").at(-1)!;
       const items = scopeData[leafName];
       // Treat a missing array the same as an empty one so that the add-target
       // remains reachable even before the first item has been submitted.
       return {
-        name: info.name,
+        name,
         count: Array.isArray(items) ? items.length : 0,
       };
     },
@@ -63,8 +67,11 @@ const simulate = <C extends PageConfigMap>(
   initialStep: NodeKey<C>,
   currentData: InferredUserData<C>,
   traverseArrays = false,
+  // Given a page and one of its addArrayItem targets, returns that array's name
+  // and item count. Passing the target lets one page add to several arrays.
   getArrayFanOut?: (
-    nodeKey: NodeKey<C>,
+    sourceKey: NodeKey<C>,
+    targetKey: NodeKey<C>,
     scopeData: Record<string, unknown>,
   ) => { name: string; count: number } | undefined,
   // A page's array-nesting depth ("/list" = 0, "/items/#/daten" = 1, …).
@@ -200,7 +207,7 @@ const simulate = <C extends PageConfigMap>(
 
       addTransitions.forEach((addTransition) => {
         if (addTransition.target == null) return;
-        const fanOut = getArrayFanOut(current, scopeData);
+        const fanOut = getArrayFanOut(current, addTransition.target, scopeData);
         if (fanOut) {
           const { name, count } = fanOut;
           // name uses "#" notation (e.g. "elternteile#kinder") but scopeData is


### PR DESCRIPTION
The begründung overview lets each section hold two nested arrays (documents and people). The engine only tracked one array per page, so it reused the first array's name and count for the second. Adding a person landed on the first page and bounced back to the overview, because the person's data was pruned to the wrong path and the next guard couldn't find it.

Fan-out now resolves the array from each addArrayItem's target instead of the shared page cache: summary pages use their declared name, others read it from the target's stepId. 