### PR TITLE
Refactor: Use function isArrayRelevant to check ausgaben arrays

### DIFF
--- a/app/domains/prozesskostenhilfe/formular/finanzielleAngaben/arrayConfiguration.ts
+++ b/app/domains/prozesskostenhilfe/formular/finanzielleAngaben/arrayConfiguration.ts
@@ -74,13 +74,15 @@ export const finanzielleAngabenArrayConfig = {
   versicherungen: {
     url: `${prefix}/ausgaben/versicherungen`,
     initialInputUrl: "daten",
-    statementKey: "hasVersicherungen",
+    isArrayRelevant: (data) =>
+      data.hasVersicherungen === "yes" && data.hasAusgaben === "yes",
     event: "add-versicherungen",
   },
   ratenzahlungen: {
     url: `${prefix}/ausgaben/ratenzahlungen`,
     initialInputUrl: "daten",
-    statementKey: "hasRatenzahlungen",
+    isArrayRelevant: (data) =>
+      data.hasRatenzahlungen === "yes" && data.hasAusgaben === "yes",
     hiddenFields: ["zahlungspflichtiger"],
     event: "add-ratenzahlungen",
   },

--- a/app/services/array/__test__/getArraySummaryData.test.ts
+++ b/app/services/array/__test__/getArraySummaryData.test.ts
@@ -1,4 +1,5 @@
 import { getArraySummaryData } from "~/services/array/getArraySummaryData";
+import { type ArrayConfigServer } from "..";
 
 describe("getArraySummaryData", () => {
   it("returns undefined when array configuration is missing", () => {
@@ -78,6 +79,24 @@ describe("getArraySummaryData", () => {
       event: addBankkonten,
       isArrayRelevant: () => false,
     } as const;
+
+    const summaryData = getArraySummaryData(
+      ["bankkonten"],
+      { bankkonten: arrayConfig },
+      { hasBankkonto: "no" },
+      [],
+    );
+
+    expect(summaryData).toEqual({});
+  });
+
+  it("should filter arrays when isRelevantArray is present and evaluates to false and it does not have statementKey", () => {
+    const arrayConfig = {
+      url: "/beratungshilfe/antrag/finanzielle-angaben/eigentum-zusammenfassung/bankkonten",
+      initialInputUrl: "daten",
+      event: addBankkonten,
+      isArrayRelevant: (data) => data.hasBankkonto === "yes",
+    } satisfies ArrayConfigServer;
 
     const summaryData = getArraySummaryData(
       ["bankkonten"],

--- a/app/services/array/getArraySummaryData.ts
+++ b/app/services/array/getArraySummaryData.ts
@@ -32,12 +32,14 @@ export function getArraySummaryData(
 
   return Object.fromEntries(
     categories
-      .filter(
-        (category) =>
-          category in arrayConfigurations &&
-          (userData[arrayConfigurations[category].statementKey] === "yes" ||
-            Boolean(arrayConfigurations[category].isArrayRelevant?.(userData))),
-      )
+      .filter((category) => {
+        if (!(category in arrayConfigurations)) return false;
+        const statementKey = arrayConfigurations[category]?.statementKey;
+        return (
+          (statementKey && userData[statementKey] === "yes") ||
+          Boolean(arrayConfigurations[category].isArrayRelevant?.(userData))
+        );
+      })
       .map((category) => {
         const arrayConfiguration = arrayConfigurations[category];
         const disableAddButton =

--- a/app/services/array/index.ts
+++ b/app/services/array/index.ts
@@ -8,7 +8,7 @@ export type ArrayConfigServer = {
   event: `add-${AllUserDataKeys}`;
   url: string;
   initialInputUrl: string;
-  statementKey: AllUserDataKeys;
+  statementKey?: AllUserDataKeys; //TODO: Remove statementKey in favor of isArrayRelevant. This is only kept for backwards compatibility with existing arrays.
   /**
    * statementKey alternative. Used for complex conditionals to display the array summary.
    */

--- a/app/services/flow/pruner/validFormPaths.ts
+++ b/app/services/flow/pruner/validFormPaths.ts
@@ -39,7 +39,10 @@ function getSubflowPaths(flowController: FlowController): Path[] {
     .filter(
       ([key, arrayConfig]) =>
         userData[key] &&
-        (userData[arrayConfig.statementKey] === "yes" ||
+        (Boolean(
+          arrayConfig.statementKey &&
+          userData[arrayConfig.statementKey] === "yes",
+        ) ||
           Boolean(arrayConfig.isArrayRelevant?.(userData))),
     )
     .filter(([_key, arrayConfig]) => {


### PR DESCRIPTION
### Problem
In the action function of `formular.ts`, we currently pass all userData saved in Redis to compute the `subflowDoneStates`. However, a bug occurs in the PKH flow: if a user initially answers "yes" to having both Ausgaben and Versicherung, but later changes their answer for Ausgaben to "no", the statementKey remains true in Redis. This stale data causes the navigation item's status in `subflowDoneStates` to incorrectly evaluate to false, preventing the user from completing the flow.

### Solution
Make the statementKey configuration optional and use isArrayRelevant to filter the Ausgaben arrays based on the current values of `hasAusgaben` and `hasVersicherung`. This ensures that `subflowDoneStates` ignores the stale Redis data and returns the correct status.

### Disclaimer
This issue will likely be resolved natively by the new engine, so this is intended as a small, interim fix.